### PR TITLE
Add PPO training and evaluation scripts

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -1,0 +1,48 @@
+import argparse
+import os
+from typing import List
+
+import numpy as np
+from stable_baselines3 import PPO
+
+from gym_tag_env import TagEnv
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Evaluate trained agent")
+    parser.add_argument("--model", type=str, default="ppo_tag.zip", help="Model path")
+    parser.add_argument("--episodes", type=int, default=10, help="Number of episodes")
+    parser.add_argument("--render", action="store_true", help="Render environment")
+    return parser.parse_args()
+
+
+def run_episode(env: TagEnv, model: PPO, render: bool) -> float:
+    obs, _ = env.reset()
+    done = False
+    total_reward = 0.0
+    while not done:
+        action, _ = model.predict(obs, deterministic=True)
+        obs, reward, done, _ = env.step(action)
+        total_reward += reward
+        if render:
+            env.render()
+    return total_reward
+
+
+def main():
+    args = parse_args()
+    if not os.path.exists(args.model):
+        raise FileNotFoundError(f"Model not found: {args.model}")
+    env = TagEnv()
+    model = PPO.load(args.model, env=env)
+
+    rewards: List[float] = []
+    for _ in range(args.episodes):
+        rewards.append(run_episode(env, model, args.render))
+
+    env.close()
+    print(f"Average reward over {args.episodes} episodes: {np.mean(rewards):.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -1,0 +1,40 @@
+import argparse
+import os
+
+from stable_baselines3 import PPO
+from stable_baselines3.common.callbacks import CheckpointCallback
+
+from gym_tag_env import TagEnv
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train PPO agent for TagEnv")
+    parser.add_argument("--timesteps", type=int, default=10000, help="Training steps per run")
+    parser.add_argument("--model", type=str, default="ppo_tag.zip", help="Path to save/load model")
+    parser.add_argument("--checkpoint-freq", type=int, default=0, help="Save checkpoints every N steps")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    env = TagEnv()
+
+    if os.path.exists(args.model):
+        model = PPO.load(args.model, env=env)
+        print(f"Loaded model from {args.model}")
+    else:
+        model = PPO("MlpPolicy", env, verbose=1)
+
+    callbacks = []
+    if args.checkpoint_freq > 0:
+        callbacks.append(
+            CheckpointCallback(save_freq=args.checkpoint_freq, save_path=".", name_prefix="ppo_checkpoint")
+        )
+
+    model.learn(total_timesteps=args.timesteps, reset_num_timesteps=False, callback=callbacks)
+    model.save(args.model)
+    print(f"Model saved to {args.model}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `train.py` with resumable PPO training
- add `evaluate.py` for model evaluation and rendering

## Testing
- `python -m py_compile train.py evaluate.py gym_tag_env.py stage_generator.py tag_game.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861597feccc832781668ffda3646a82