### PR TITLE
Add training render option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,15 @@ python3 tag_game.py
 `reset()` でステージとエージェントを再初期化し、`step(action)` では加速度ベースで
 移動させながら報酬と終了判定を返します。行動・観測はいずれも `spaces.Box` により
 連続値として定義しています。`render()` を呼び出すと pygame で状態を描画します。
+
+## 学習
+
+`train.py` では Stable-Baselines3 の PPO を用いた学習が行えます。
+学習中にマップと各エージェントの視野を表示したい場合は `--render` オプションを
+指定してください。
+
+```bash
+python3 train.py --timesteps 50000 --render
+```
+
+描画更新間隔は `--render-interval` で指定できます (デフォルト1ステップごと)。

--- a/train.py
+++ b/train.py
@@ -2,7 +2,7 @@ import argparse
 import os
 
 from stable_baselines3 import PPO
-from stable_baselines3.common.callbacks import CheckpointCallback
+from stable_baselines3.common.callbacks import CheckpointCallback, BaseCallback
 
 from gym_tag_env import TagEnv
 
@@ -12,7 +12,23 @@ def parse_args():
     parser.add_argument("--timesteps", type=int, default=10000, help="Training steps per run")
     parser.add_argument("--model", type=str, default="ppo_tag.zip", help="Path to save/load model")
     parser.add_argument("--checkpoint-freq", type=int, default=0, help="Save checkpoints every N steps")
+    parser.add_argument("--render", action="store_true", help="Render environment during training")
+    parser.add_argument("--render-interval", type=int, default=1, help="Render every N steps when --render is set")
     return parser.parse_args()
+
+
+class RenderCallback(BaseCallback):
+    """Render environment during training if ``--render`` is specified."""
+
+    def __init__(self, env: TagEnv, render_interval: int = 1, verbose: int = 0):
+        super().__init__(verbose)
+        self.env = env
+        self.render_interval = max(1, render_interval)
+
+    def _on_step(self) -> bool:  # type: ignore[override]
+        if self.n_calls % self.render_interval == 0:
+            self.env.render()
+        return True
 
 
 def main():
@@ -30,6 +46,8 @@ def main():
         callbacks.append(
             CheckpointCallback(save_freq=args.checkpoint_freq, save_path=".", name_prefix="ppo_checkpoint")
         )
+    if args.render:
+        callbacks.append(RenderCallback(env, render_interval=args.render_interval))
 
     model.learn(total_timesteps=args.timesteps, reset_num_timesteps=False, callback=callbacks)
     model.save(args.model)


### PR DESCRIPTION
## Summary
- add optional rendering during PPO training via `RenderCallback`
- document `--render` and `--render-interval` usage

## Testing
- `python3 -m py_compile gym_tag_env.py tag_game.py stage_generator.py train.py evaluate.py`
- `SDL_VIDEODRIVER=dummy python3 train.py --timesteps 1 --render --render-interval 1` *(fails: not enough values to unpack)*

------
https://chatgpt.com/codex/tasks/task_e_68615ba82b008327ada98cf002877703