### PR TITLE
Update TagEnv step API

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -22,7 +22,8 @@ def run_episode(env: TagEnv, model: PPO, render: bool) -> float:
     total_reward = 0.0
     while not done:
         action, _ = model.predict(obs, deterministic=True)
-        obs, reward, done, _ = env.step(action)
+        obs, reward, terminated, truncated, _ = env.step(action)
+        done = terminated or truncated
         total_reward += reward
         if render:
             env.render()

--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -14,7 +14,7 @@ from tag_game import StageMap, Agent, CELL_SIZE
 
 
 class TagEnv(gym.Env):
-    metadata = {"render.modes": ["human"]}
+    metadata = {"render_modes": ["human"]}
 
     def __init__(self, width: int = 31, height: int = 21, max_steps: int = 500):
         super().__init__()
@@ -54,10 +54,11 @@ class TagEnv(gym.Env):
         self.nige.update(self.stage)
 
         obs = np.array(self.oni.observe(self.nige), dtype=np.float32)
-        done = self.oni.collides_with(self.nige) or self.step_count >= self.max_steps
-        reward = 1.0 if self.oni.collides_with(self.nige) else -0.01
+        terminated = self.oni.collides_with(self.nige)
+        truncated = self.step_count >= self.max_steps
+        reward = 1.0 if terminated else -0.01
         info = {}
-        return obs, reward, done, info
+        return obs, reward, terminated, truncated, info
 
     def render(self):
         if self.screen is None:


### PR DESCRIPTION
## Summary
- modify `TagEnv` metadata
- update `TagEnv.step()` to return `(obs, reward, terminated, truncated, info)`
- adjust evaluation loop to use new return values

## Testing
- `python3 -m py_compile gym_tag_env.py evaluate.py train.py stage_generator.py tag_game.py`

------
https://chatgpt.com/codex/tasks/task_e_68615f0c7858832789525d38ce14a42c