### PR TITLE
Use gymnasium RNG

### DIFF
--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -35,8 +35,9 @@ class TagEnv(gym.Env):
     def reset(self, *, seed: int | None = None, options=None):
         super().reset(seed=seed)
         if seed is not None:
+            np.random.seed(seed)
             random.seed(seed)
-        self.stage = StageMap(self.width, self.height)
+        self.stage = StageMap(self.width, self.height, rng=self.np_random)
         self.oni = Agent(1.5, 1.5, (255, 0, 0))
         self.nige = Agent(self.width - 2, self.height - 2, (0, 100, 255))
         self.step_count = 0
@@ -48,7 +49,7 @@ class TagEnv(gym.Env):
         dx, dy = float(action[0]), float(action[1])
         self.oni.set_direction(dx, dy)
         # random policy for escapee
-        rnd = np.random.uniform(-1, 1, size=2)
+        rnd = self.np_random.uniform(-1, 1, size=2)
         self.nige.set_direction(float(rnd[0]), float(rnd[1]))
         self.oni.update(self.stage)
         self.nige.update(self.stage)

--- a/tag_game.py
+++ b/tag_game.py
@@ -1,10 +1,10 @@
 import math
-import random
 from typing import Tuple, List
 
 import pygame
 
 from stage_generator import generate_stage, Stage
+import numpy as np
 
 
 CELL_SIZE = 20
@@ -13,8 +13,9 @@ FOV_DIST = 5
 
 
 class StageMap:
-    def __init__(self, width: int, height: int):
-        self.grid = generate_stage(width, height)
+    def __init__(self, width: int, height: int, rng: np.random.Generator | None = None):
+        self.rng = rng or np.random.default_rng()
+        self.grid = generate_stage(width, height, rng=self.rng)
         self.width = width
         self.height = height
 


### PR DESCRIPTION
## Summary
- ensure reproducibility by seeding numpy RNG in `TagEnv.reset`
- propagate the gymnasium RNG to stage generation and action sampling
- refactor stage generator to use `numpy.random.Generator`
- update `StageMap` to accept an RNG

## Testing
- `python3 -m py_compile gym_tag_env.py stage_generator.py tag_game.py`
- `python3 stage_generator.py | head -n 3`
- `python3 - <<'EOF'
from gym_tag_env import TagEnv
env = TagEnv()
obs, _ = env.reset(seed=42)
print('obs', obs)
for _ in range(2):
    obs, reward, done, _ = env.step(env.action_space.sample())
    print('step', obs, reward, done)
print('stage shape', len(env.stage.grid))
EOF

------
https://chatgpt.com/codex/tasks/task_e_68615f110cbc8327a0a7d3e507ca0a97