### PR TITLE
Add option for denser wall generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ python3 stage_generator.py
 実行すると固定サイズ（例: 31x21）のステージが標準出力に表示されます。
 `generate_stage` 関数に幅・高さを指定することで別サイズのステージも生成可能です。
 ステージには行き止まりが存在しないよう調整されており、道幅はランダムで広げられます。
+壁密度を高めたい場合は `generate_stage(width, height, extra_wall_prob=0.1)` のように
+`extra_wall_prob` を指定してください。
 
 ## 鬼ごっこ環境
 
@@ -26,6 +28,7 @@ python3 tag_game.py
 `reset()` でステージとエージェントを再初期化し、`step(action)` では加速度ベースで
 移動させながら報酬と終了判定を返します。行動・観測はいずれも `spaces.Box` により
 連続値として定義しています。`render()` を呼び出すと pygame で状態を描画します。
+`TagEnv` のコンストラクタ引数 `extra_wall_prob` で壁密度を調整できます。
 
 ## 学習
 

--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -16,11 +16,18 @@ from tag_game import StageMap, Agent, CELL_SIZE
 class TagEnv(gym.Env):
     metadata = {"render_modes": ["human"]}
 
-    def __init__(self, width: int = 31, height: int = 21, max_steps: int = 500):
+    def __init__(
+        self,
+        width: int = 31,
+        height: int = 21,
+        max_steps: int = 500,
+        extra_wall_prob: float = 0.0,
+    ):
         super().__init__()
         self.width = width
         self.height = height
         self.max_steps = max_steps
+        self.extra_wall_prob = extra_wall_prob
         self.stage: StageMap | None = None
         self.oni: Agent | None = None
         self.nige: Agent | None = None
@@ -37,7 +44,12 @@ class TagEnv(gym.Env):
         if seed is not None:
             np.random.seed(seed)
             random.seed(seed)
-        self.stage = StageMap(self.width, self.height, rng=self.np_random)
+        self.stage = StageMap(
+            self.width,
+            self.height,
+            extra_wall_prob=self.extra_wall_prob,
+            rng=self.np_random,
+        )
         self.oni = Agent(1.5, 1.5, (255, 0, 0))
         self.nige = Agent(self.width - 2, self.height - 2, (0, 100, 255))
         self.step_count = 0

--- a/stage_generator.py
+++ b/stage_generator.py
@@ -69,7 +69,27 @@ def widen_paths(stage: Stage, width_range: Tuple[int, int], rng: np.random.Gener
                             stage[ny][nx] = 0
     return stage
 
-def generate_stage(width: int, height: int, path_width: Tuple[int, int] = (1, 2), rng: np.random.Generator | None = None) -> Stage:
+def add_random_walls(stage: Stage, prob: float, rng: np.random.Generator) -> Stage:
+    """Randomly convert path cells back into walls."""
+    if prob <= 0:
+        return stage
+    h, w = len(stage), len(stage[0])
+    for y in range(1, h-1):
+        for x in range(1, w-1):
+            if stage[y][x] == 0 and rng.random() < prob:
+                stage[y][x] = 1
+    # ensure start and goal remain open
+    stage[1][1] = 0
+    stage[h-2][w-2] = 0
+    return stage
+
+def generate_stage(
+    width: int,
+    height: int,
+    path_width: Tuple[int, int] = (1, 2),
+    extra_wall_prob: float = 0.0,
+    rng: np.random.Generator | None = None,
+) -> Stage:
     if rng is None:
         rng = np.random.default_rng()
     if width % 2 == 0 or height % 2 == 0:
@@ -77,6 +97,7 @@ def generate_stage(width: int, height: int, path_width: Tuple[int, int] = (1, 2)
     stage = generate_maze(width, height, rng)
     stage = remove_dead_ends(stage, rng)
     stage = widen_paths(stage, path_width, rng)
+    stage = add_random_walls(stage, extra_wall_prob, rng)
     return stage
 
 def print_stage(stage: Stage) -> None:

--- a/tag_game.py
+++ b/tag_game.py
@@ -10,12 +10,19 @@ import numpy as np
 CELL_SIZE = 20
 FOV_DEG = 120
 FOV_DIST = 5
+EXTRA_WALL_PROB = 0.1
 
 
 class StageMap:
-    def __init__(self, width: int, height: int, rng: np.random.Generator | None = None):
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        extra_wall_prob: float = 0.0,
+        rng: np.random.Generator | None = None,
+    ):
         self.rng = rng or np.random.default_rng()
-        self.grid = generate_stage(width, height, rng=self.rng)
+        self.grid = generate_stage(width, height, extra_wall_prob=extra_wall_prob, rng=self.rng)
         self.width = width
         self.height = height
 
@@ -159,7 +166,7 @@ def get_state(oni: Agent, nige: Agent) -> Tuple[List[float], List[float]]:
 def main():
     pygame.init()
     width, height = 31, 21
-    stage = StageMap(width, height)
+    stage = StageMap(width, height, extra_wall_prob=EXTRA_WALL_PROB)
 
     screen = pygame.display.set_mode((width * CELL_SIZE, height * CELL_SIZE))
     clock = pygame.time.Clock()


### PR DESCRIPTION
## Summary
- introduce `extra_wall_prob` to increase wall density during stage generation
- expose the parameter through `StageMap` and `TagEnv`
- use this parameter in the sample game
- document how to use the option in README

## Testing
- `python3 -m py_compile stage_generator.py tag_game.py gym_tag_env.py`
- `python3 stage_generator.py | head`
- `python3 tag_game.py` *(fails: XDG_RUNTIME_DIR is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686166f02a2083278f33c1dbf483903e