### PR TITLE
Add training options for repeated parallel runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ py train.py --timesteps 50000 --render
 ```
 
 描画更新間隔は `--render-interval` で指定できます (デフォルト1ステップごと)。
+学習時間を秒単位で制限したい場合は `--duration` を用います。複数回の学習を行う
+場合は `--runs` で回数を、`--parallel` で並列実行数を指定できます。環境の描画速度
+を調整する `--speed-multiplier` オプションも利用可能です。

--- a/evaluate.py
+++ b/evaluate.py
@@ -13,6 +13,7 @@ def parse_args():
     parser.add_argument("--model", type=str, default="ppo_tag.zip", help="Model path")
     parser.add_argument("--episodes", type=int, default=10, help="Number of episodes")
     parser.add_argument("--render", action="store_true", help="Render environment")
+    parser.add_argument("--speed-multiplier", type=float, default=1.0, help="Environment speed multiplier")
     return parser.parse_args()
 
 
@@ -34,7 +35,7 @@ def main():
     args = parse_args()
     if not os.path.exists(args.model):
         raise FileNotFoundError(f"Model not found: {args.model}")
-    env = TagEnv()
+    env = TagEnv(speed_multiplier=args.speed_multiplier)
     model = PPO.load(args.model, env=env)
 
     rewards: List[float] = []

--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -22,6 +22,7 @@ class TagEnv(gym.Env):
         height: int = 21,
         max_steps: int = 500,
         extra_wall_prob: float = 0.0,
+        speed_multiplier: float = 1.0,
     ):
         super().__init__()
         self.width = width
@@ -36,6 +37,7 @@ class TagEnv(gym.Env):
         self.observation_space = spaces.Box(low=low, high=high, dtype=np.float32)
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
         self.step_count = 0
+        self.speed_multiplier = max(0.1, speed_multiplier)
         self.screen: pygame.Surface | None = None
         self.clock: pygame.time.Clock | None = None
 
@@ -104,7 +106,7 @@ class TagEnv(gym.Env):
             )
         pygame.display.flip()
         if self.clock:
-            self.clock.tick(60)
+            self.clock.tick(60 * self.speed_multiplier)
 
     def close(self):
         if self.screen:


### PR DESCRIPTION
## Summary
- support new options for training: duration, runs, parallel and speed multiplier
- allow TagEnv to run faster via speed multiplier
- support speed multiplier in evaluation script
- document the new training options in README

## Testing
- `python -m py_compile *.py`
- `pip install -r requirements.txt`
- `python train.py --timesteps 1 --duration 1 --runs 1 --parallel 1 --speed-multiplier 2.0`
- `python evaluate.py --model ppo_tag_0.zip --episodes 1 --speed-multiplier 2.0`


------
https://chatgpt.com/codex/tasks/task_e_68616aa5aed08327bb8803b89291f402