### PR TITLE
Remove FOV logic for direct agent awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install -r requirements.txt
 ```
 
 `train.py` では Stable-Baselines3 の PPO を用いた学習が行えます。
-学習中にマップと各エージェントの視野を表示したい場合は `--render` オプションを
+学習中にマップと各エージェントの状態を表示したい場合は `--render` オプションを
 指定してください。
 
 ```bash

--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 """Gym environment for the tag game."""
-import math
 import random
 from typing import Tuple, List
 
@@ -32,8 +31,8 @@ class TagEnv(gym.Env):
         self.stage: StageMap | None = None
         self.oni: Agent | None = None
         self.nige: Agent | None = None
-        low = np.array([-width, -height, 0], dtype=np.float32)
-        high = np.array([width, height, 1], dtype=np.float32)
+        low = np.array([-width, -height], dtype=np.float32)
+        high = np.array([width, height], dtype=np.float32)
         self.observation_space = spaces.Box(low=low, high=high, dtype=np.float32)
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
         self.step_count = 0
@@ -90,20 +89,19 @@ class TagEnv(gym.Env):
         self.stage.draw(self.screen)
         self.oni.draw(self.screen)
         self.nige.draw(self.screen)
-        if self.oni.can_see(self.nige):
-            pygame.draw.line(
-                self.screen,
-                (255, 0, 0),
-                (
-                    int(self.oni.pos.x * CELL_SIZE + CELL_SIZE / 2),
-                    int(self.oni.pos.y * CELL_SIZE + CELL_SIZE / 2),
-                ),
-                (
-                    int(self.nige.pos.x * CELL_SIZE + CELL_SIZE / 2),
-                    int(self.nige.pos.y * CELL_SIZE + CELL_SIZE / 2),
-                ),
-                2,
-            )
+        pygame.draw.line(
+            self.screen,
+            (255, 0, 0),
+            (
+                int(self.oni.pos.x * CELL_SIZE + CELL_SIZE / 2),
+                int(self.oni.pos.y * CELL_SIZE + CELL_SIZE / 2),
+            ),
+            (
+                int(self.nige.pos.x * CELL_SIZE + CELL_SIZE / 2),
+                int(self.nige.pos.y * CELL_SIZE + CELL_SIZE / 2),
+            ),
+            2,
+        )
         pygame.display.flip()
         if self.clock:
             self.clock.tick(60 * self.speed_multiplier)


### PR DESCRIPTION
## Summary
- remove field-of-view constants and visibility checks
- observations now just include relative position
- always draw a line between oni and nige
- update README to reflect rendering changes

## Testing
- `python -m py_compile tag_game.py gym_tag_env.py stage_generator.py train.py evaluate.py`

------
https://chatgpt.com/codex/tasks/task_e_68616f75fb8c8327ad596a7ee2aa796e