### PR TITLE
Display step count when rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ pip install -r requirements.txt
 `train.py` では Stable-Baselines3 の PPO を用いた学習が行えます。
 学習中にマップと各エージェントの状態を表示したい場合は `--render` オプションを
 指定してください。
+描画時には現在のステップ数も画面左上に表示されます。
 
 ```bash
 py train.py --timesteps 50000 --render

--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -188,6 +188,10 @@ class TagEnv(gym.Env):
             ),
             2,
         )
+        # Display current step count
+        font = pygame.font.SysFont(None, 24)
+        step_text = font.render(f"Step: {self.step_count}", True, (0, 0, 0))
+        self.screen.blit(step_text, (10, 10))
         pygame.display.flip()
         if self.clock:
             self.clock.tick(60 * self.speed_multiplier)


### PR DESCRIPTION
## Summary
- show current step count in `TagEnv.render()`
- mention step count overlay in README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861723ac4d08327be47d348718cc205