### PR TITLE
Add time and reward display

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ pip install -r requirements.txt
 `train.py` では Stable-Baselines3 の PPO を用いた学習が行えます。
 学習中にマップと各エージェントの状態を表示したい場合は `--render` オプションを
 指定してください。
-描画時には現在のステップ数も画面左上に表示されます。
+描画時にはステップ数の代わりに残り時間や実行回数、
+鬼と逃げの累積報酬が画面上部に表示されます。
 
 ```bash
 py train.py --timesteps 50000 --render

--- a/evaluate.py
+++ b/evaluate.py
@@ -46,7 +46,10 @@ def main():
     nige_model = PPO.load(args.nige_model, env=env)
 
     rewards: List[Tuple[float, float]] = []
-    for _ in range(args.episodes):
+    for i in range(args.episodes):
+        env.current_run = i + 1
+        env.total_runs = args.episodes
+        env.remaining_time = 0.0
         rewards.append(run_episode(env, oni_model, nige_model, args.render))
 
     env.close()

--- a/tag_game.py
+++ b/tag_game.py
@@ -44,16 +44,17 @@ class StageMap:
                         return True
         return False
 
-    def draw(self, screen: pygame.Surface) -> None:
+    def draw(self, screen: pygame.Surface, offset: Tuple[int, int] = (0, 0)) -> None:
         wall_color = (40, 40, 40)
         floor_color = (200, 200, 200)
+        off_x, off_y = offset
         for y, row in enumerate(self.grid):
             for x, cell in enumerate(row):
                 color = wall_color if cell == 1 else floor_color
                 pygame.draw.rect(
                     screen,
                     color,
-                    pygame.Rect(x * CELL_SIZE, y * CELL_SIZE, CELL_SIZE, CELL_SIZE),
+                    pygame.Rect(off_x + x * CELL_SIZE, off_y + y * CELL_SIZE, CELL_SIZE, CELL_SIZE),
                 )
 
 
@@ -105,11 +106,15 @@ class Agent:
 
         self.pos.update(new_x, new_y)
 
-    def draw(self, screen: pygame.Surface) -> None:
+    def draw(self, screen: pygame.Surface, offset: Tuple[int, int] = (0, 0)) -> None:
+        off_x, off_y = offset
         pygame.draw.circle(
             screen,
             self.color,
-            (int(self.pos.x * CELL_SIZE + CELL_SIZE / 2), int(self.pos.y * CELL_SIZE + CELL_SIZE / 2)),
+            (
+                int(off_x + self.pos.x * CELL_SIZE + CELL_SIZE / 2),
+                int(off_y + self.pos.y * CELL_SIZE + CELL_SIZE / 2),
+            ),
             self.radius,
         )
 


### PR DESCRIPTION
## Summary
- show remaining time, run count, and rewards when rendering environments
- provide render support in `MultiTagEnv`
- add info panel offset support in `StageMap` and `Agent`
- expose run and timing info during training and evaluation
- update docs accordingly

## Testing
- `python -m py_compile tag_game.py gym_tag_env.py train.py evaluate.py stage_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_6861779b609c8327be5c2de356055807