### PR TITLE
Add white background info panel

### DIFF
--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -130,6 +130,11 @@ class MultiTagEnv(gym.Env):
                 self.screen = None
                 return
         self.screen.fill((0, 0, 0))
+        pygame.draw.rect(
+            self.screen,
+            (255, 255, 255),
+            pygame.Rect(0, 0, self.width * CELL_SIZE, INFO_PANEL_HEIGHT),
+        )
         offset = (0, INFO_PANEL_HEIGHT)
         self.stage.draw(self.screen, offset)
         self.oni.draw(self.screen, offset)
@@ -244,6 +249,11 @@ class TagEnv(gym.Env):
                 self.screen = None
                 return
         self.screen.fill((0, 0, 0))
+        pygame.draw.rect(
+            self.screen,
+            (255, 255, 255),
+            pygame.Rect(0, 0, self.width * CELL_SIZE, INFO_PANEL_HEIGHT),
+        )
         offset = (0, INFO_PANEL_HEIGHT)
         self.stage.draw(self.screen, offset)
         self.oni.draw(self.screen, offset)


### PR DESCRIPTION
## Summary
- show the info panel (remaining time, etc.) on a white background with black text

## Testing
- `python3 -m py_compile gym_tag_env.py tag_game.py stage_generator.py train.py evaluate.py`
- `python3 -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6861e30d473c8327a2989f3bf0aae1df