### PR TITLE
Default to simultaneous training

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,26 +34,19 @@ py tag_game.py
 pip install -r requirements.txt
 ```
 
-`train.py` では Stable-Baselines3 の PPO を用いた学習が行えます。
-学習中にマップと各エージェントの状態を表示したい場合は `--render` オプションを
-指定してください。
-描画時にはステップ数の代わりに残り時間や実行回数、
-鬼と逃げの累積報酬が画面上部に表示されます。
+`train.py` は 鬼と逃げを同時に学習する自作ポリシー勾配方式がデフォルトです。
+`--mode alternate` を指定すると Stable-Baselines3 を用いた交互学習に切り替えられます。
+学習中にマップと各エージェントの状態を表示したい場合は `--render` オプションを指定してください。
+描画時にはステップ数の代わりに残り時間や実行回数、鬼と逃げの累積報酬が画面上部に表示されます。
 
 ```bash
-py train.py --timesteps 50000 --render
+py train.py --episodes 1000 --render
 ```
 
 描画更新間隔は `--render-interval` で指定できます (デフォルト1ステップごと)。
-学習時間を秒単位で制限したい場合は `--duration` を用います。`--num-envs` を指定すると1つの学習で複数環境を同時に利用できます。環境の描画速度を調整する `--speed-multiplier` オプションも利用可能です。`train.py` では内部で `EpisodeSwapEnv` を用いて 1 エピソードごとに鬼と逃げの学習対象を自動的に切り替えます。学習エピソード数は `--episodes` で指定できます。
-学習後、鬼側モデルは `oni_<run>.zip`、逃げ側モデルは `nige_<run>.zip` として保存されます。
+学習時間を秒単位で制限したい場合は `--duration` を用います。`--num-envs` を指定すると1つの学習で複数環境を同時に利用できます。環境の描画速度を調整する `--speed-multiplier` オプションも利用可能です。交互学習モードでは `EpisodeSwapEnv` を利用し、鬼と逃げをエピソードごとに切り替えて学習します。
+学習後、鬼側モデルは `oni_selfplay.pth`、逃げ側モデルは `nige_selfplay.pth` として保存されます。
 
-## 同時学習
+## 旧 self-play スクリプト
 
-`train_selfplay.py` を使うと、鬼と逃げの両方を同じエピソードから同時に学習させる簡易的な自作ポリシー勾配による学習が行えます。Stable-Baselines3 は利用せず、PyTorch を用いた軽量実装です。
-
-```bash
-py train_selfplay.py --episodes 1000 --render
-```
-
-学習が終了すると `oni_selfplay.pth` と `nige_selfplay.pth` に各ポリシーの重みが保存されます。
+以前は `train_selfplay.py` を用いて同時学習を行っていましたが、`train.py` に統合したため基本的には使用不要です。残してありますが機能は同等です。

--- a/train.py
+++ b/train.py
@@ -2,11 +2,15 @@ import argparse
 import os
 
 import gymnasium as gym
+import torch
+import torch.nn as nn
+import torch.optim as optim
 
 from stable_baselines3 import PPO
 from stable_baselines3.common.callbacks import CheckpointCallback, BaseCallback
 
 from episode_swap_env import EpisodeSwapEnv
+from gym_tag_env import MultiTagEnv
 from stable_baselines3.common.env_util import make_vec_env
 
 
@@ -22,6 +26,9 @@ def parse_args():
     parser.add_argument("--episodes", type=int, default=10, help="Number of episodes")
     parser.add_argument("--speed-multiplier", type=float, default=1.0, help="Environment speed multiplier")
     parser.add_argument("--num-envs", type=int, default=1, help="Number of parallel environments")
+    parser.add_argument("--mode", choices=["selfplay", "alternate"], default="selfplay", help="Training mode")
+    parser.add_argument("--gamma", type=float, default=0.99, help="Discount factor for self-play")
+    parser.add_argument("--lr", type=float, default=3e-4, help="Learning rate for self-play")
     return parser.parse_args()
 
 
@@ -51,6 +58,90 @@ def _create_env(args: argparse.Namespace):
             n_envs=args.num_envs,
         )
     return EpisodeSwapEnv(speed_multiplier=args.speed_multiplier)
+
+
+class Policy(nn.Module):
+    def __init__(self, input_dim: int = 2, hidden_dim: int = 64, output_dim: int = 2):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.Tanh(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.Tanh(),
+        )
+        self.mean = nn.Linear(hidden_dim, output_dim)
+        self.log_std = nn.Parameter(torch.zeros(output_dim))
+
+    def forward(self, x: torch.Tensor):
+        h = self.net(x)
+        return self.mean(h), self.log_std.exp()
+
+    def act(self, obs: torch.Tensor):
+        mean, std = self(obs)
+        dist = torch.distributions.Normal(mean, std)
+        action = dist.rsample()
+        log_prob = dist.log_prob(action).sum(dim=-1)
+        return action, log_prob
+
+
+def compute_returns(rewards, gamma: float):
+    returns = []
+    R = 0.0
+    for r in reversed(rewards):
+        R = r + gamma * R
+        returns.insert(0, R)
+    return returns
+
+
+def run_selfplay(args: argparse.Namespace) -> None:
+    env = MultiTagEnv(speed_multiplier=args.speed_multiplier)
+    oni_policy = Policy()
+    nige_policy = Policy()
+    oni_optim = optim.Adam(oni_policy.parameters(), lr=args.lr)
+    nige_optim = optim.Adam(nige_policy.parameters(), lr=args.lr)
+
+    for ep in range(1, args.episodes + 1):
+        obs, _ = env.reset()
+        oni_obs, nige_obs = obs
+        oni_log_probs = []
+        nige_log_probs = []
+        oni_rewards = []
+        nige_rewards = []
+        done = False
+        while not done:
+            oni_action, oni_logp = oni_policy.act(torch.tensor(oni_obs, dtype=torch.float32))
+            nige_action, nige_logp = nige_policy.act(torch.tensor(nige_obs, dtype=torch.float32))
+            (oni_obs, nige_obs), (r_o, r_n), terminated, truncated, _ = env.step((
+                oni_action.detach().numpy(),
+                nige_action.detach().numpy(),
+            ))
+            if args.render:
+                env.render()
+            oni_log_probs.append(oni_logp)
+            nige_log_probs.append(nige_logp)
+            oni_rewards.append(r_o)
+            nige_rewards.append(r_n)
+            done = terminated or truncated
+
+        oni_returns = torch.tensor(compute_returns(oni_rewards, args.gamma), dtype=torch.float32)
+        nige_returns = torch.tensor(compute_returns(nige_rewards, args.gamma), dtype=torch.float32)
+        oni_loss = -(torch.stack(oni_log_probs) * oni_returns).sum()
+        nige_loss = -(torch.stack(nige_log_probs) * nige_returns).sum()
+
+        oni_optim.zero_grad()
+        oni_loss.backward()
+        oni_optim.step()
+
+        nige_optim.zero_grad()
+        nige_loss.backward()
+        nige_optim.step()
+
+        if ep % 10 == 0:
+            print(f"episode {ep}: oniR={sum(oni_rewards):.2f} nigeR={sum(nige_rewards):.2f}")
+
+    torch.save(oni_policy.state_dict(), args.oni_model.replace('.zip', '_selfplay.pth'))
+    torch.save(nige_policy.state_dict(), args.nige_model.replace('.zip', '_selfplay.pth'))
+    env.close()
 
 
 def run_single(run_idx: int, args: argparse.Namespace) -> None:
@@ -129,7 +220,10 @@ def run_single(run_idx: int, args: argparse.Namespace) -> None:
 
 def main():
     args = parse_args()
-    run_single(0, args)
+    if args.mode == "selfplay":
+        run_selfplay(args)
+    else:
+        run_single(0, args)
 
 
 


### PR DESCRIPTION
## Summary
- update `train.py` so self-play training is default
- add simple self-play implementation in `train.py`
- import MultiTagEnv and other deps for self-play
- update README to document new default and note the old self-play script

## Testing
- `python -m py_compile train.py evaluate.py gym_tag_env.py tag_game.py episode_swap_env.py train_selfplay.py stage_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_6861f7c5bf5c8327b7e704096f116f43