### PR TITLE
Fix VecEnv handling

### DIFF
--- a/episode_swap_env.py
+++ b/episode_swap_env.py
@@ -36,6 +36,14 @@ class EpisodeSwapEnv(gym.Env):
         self.action_space = self.base_env.action_space
         self._last_obs: tuple[np.ndarray, np.ndarray] | None = None
 
+    def set_run_info(self, current_run: int, total_runs: int) -> None:
+        """Set current episode index and total runs for rendering."""
+        self.base_env.set_run_info(current_run, total_runs)
+
+    def set_training_end_time(self, end_time: float | None) -> None:
+        """Set training end time used by the renderer."""
+        self.base_env.set_training_end_time(end_time)
+
     def set_training_agent(self, agent: str) -> None:
         """Manually override the agent trained in the next episode."""
         assert agent in ("oni", "nige")

--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -55,6 +55,15 @@ class MultiTagEnv(gym.Env):
         self.total_runs: int = 1
         self.training_end_time: float | None = None
 
+    def set_run_info(self, current_run: int, total_runs: int) -> None:
+        """Set current episode index and total runs for rendering."""
+        self.current_run = current_run
+        self.total_runs = total_runs
+
+    def set_training_end_time(self, end_time: float | None) -> None:
+        """Set training end time used by the renderer."""
+        self.training_end_time = end_time
+
     def reset(
         self,
         *,
@@ -204,6 +213,15 @@ class TagEnv(gym.Env):
         self.current_run: int = 0
         self.total_runs: int = 1
         self.training_end_time: float | None = None
+
+    def set_run_info(self, current_run: int, total_runs: int) -> None:
+        """Set current episode index and total runs for rendering."""
+        self.current_run = current_run
+        self.total_runs = total_runs
+
+    def set_training_end_time(self, end_time: float | None) -> None:
+        """Set training end time used by the renderer."""
+        self.training_end_time = end_time
 
     def reset(
         self,


### PR DESCRIPTION
## Summary
- handle VecEnv attributes correctly in `train.py`
- add run info helpers in `gym_tag_env.py`
- delegate run info helpers from `EpisodeSwapEnv`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ffb3591c8327ac42d6b95f71a1a6