### PR TITLE
Fix training display info

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ pip install -r requirements.txt
 `--mode alternate` を指定すると Stable-Baselines3 を用いた交互学習に切り替えられます。
 学習中にマップと各エージェントの状態を表示したい場合は `--render` オプションを指定してください。
 描画時にはステップ数の代わりに残り時間や実行回数、鬼と逃げの累積報酬が画面上部に表示されます。
+`train.py` では各エピソード開始時にこれらの値を自動設定するため、表示が常に最新の状態に保たれます。
 
 ```bash
 py train.py --episodes 1000 --render

--- a/train.py
+++ b/train.py
@@ -102,6 +102,9 @@ def run_selfplay(args: argparse.Namespace) -> None:
     nige_optim = optim.Adam(nige_policy.parameters(), lr=args.lr)
 
     for ep in range(1, args.episodes + 1):
+        env.set_run_info(ep, args.episodes)
+        import time
+        env.set_training_end_time(time.time() + args.duration)
         obs, _ = env.reset()
         oni_obs, nige_obs = obs
         oni_log_probs = []


### PR DESCRIPTION
## Summary
- ensure remaining time and run numbers update in self-play training
- document automatic info updates in README

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862983bc2f08327b90f6869d0ecc8ac