### PR TITLE
Fix training timer scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ pip install -r requirements.txt
 `--mode alternate` を指定すると Stable-Baselines3 を用いた交互学習に切り替えられます。
 学習中にマップと各エージェントの状態を表示したい場合は `--render` オプションを指定してください。
 描画時にはステップ数の代わりに残り時間や実行回数、鬼と逃げの累積報酬が画面上部に表示されます。
+`train.py` では各エピソード開始時にこれらの値を自動設定するため、表示が常に最新の状態に保たれます。
 
 ```bash
 py train.py --episodes 1000 --render
 ```
 
 描画更新間隔は `--render-interval` で指定できます (デフォルト1ステップごと)。
-学習時間を秒単位で制限したい場合は `--duration` を用います。`--num-envs` を指定すると1つの学習で複数環境を同時に利用できます。環境の描画速度を調整する `--speed-multiplier` オプションも利用可能です。交互学習モードでは `EpisodeSwapEnv` を利用し、鬼と逃げをエピソードごとに切り替えて学習します。
+学習時間を秒単位で制限したい場合は `--duration` を用います。`--num-envs` を指定すると1つの学習で複数環境を同時に利用できます。環境の描画速度を調整する `--speed-multiplier` オプションも利用可能です。`--duration` で指定した値は環境時間なので、`--speed-multiplier` が 2 の場合、実際の経過時間はその半分になります。交互学習モードでは `EpisodeSwapEnv` を利用し、鬼と逃げをエピソードごとに切り替えて学習します。
 学習後、鬼側モデルは `oni_selfplay.pth`、逃げ側モデルは `nige_selfplay.pth` として保存されます。
 
 ## 旧 self-play スクリプト
@@ -71,9 +72,9 @@ py train.py --episodes 1000 --render
 | `--checkpoint-freq <int>` | 指定間隔でチェックポイント保存 | 0 |
 | `--render` | 学習中に画面を描画 | - |
 | `--render-interval <int>` | 描画間隔(ステップ数) | 1 |
-| `--duration <秒>` | 各エピソードの学習時間 | 10 |
+| `--duration <秒>` | 各エピソードの学習時間（環境時間） | 10 |
 | `--episodes <int>` | 総エピソード数 | 10 |
-| `--speed-multiplier <float>` | 環境の処理速度倍率 | 1.0 |
+| `--speed-multiplier <float>` | 環境の処理速度倍率（タイマーも連動） | 1.0 |
 | `--num-envs <int>` | 並列環境数 | 1 |
 | `--mode {selfplay,alternate}` | 学習モード | `selfplay` |
 | `--gamma <float>` | 自作ポリシー勾配用の割引率 | 0.99 |

--- a/train.py
+++ b/train.py
@@ -102,6 +102,10 @@ def run_selfplay(args: argparse.Namespace) -> None:
     nige_optim = optim.Adam(nige_policy.parameters(), lr=args.lr)
 
     for ep in range(1, args.episodes + 1):
+        env.set_run_info(ep, args.episodes)
+        import time
+        scaled_duration = args.duration / args.speed_multiplier
+        env.set_training_end_time(time.time() + scaled_duration)
         obs, _ = env.reset()
         oni_obs, nige_obs = obs
         oni_log_probs = []
@@ -195,12 +199,13 @@ def run_single(run_idx: int, args: argparse.Namespace) -> None:
 
         import time
         start = time.time()
+        scaled_duration = args.duration / args.speed_multiplier
         if isinstance(env, VecEnv):
-            env.env_method("set_training_end_time", start + args.duration)
+            env.env_method("set_training_end_time", start + scaled_duration)
         else:
-            env.set_training_end_time(start + args.duration)
+            env.set_training_end_time(start + scaled_duration)
         model = oni_model if train_oni else nige_model
-        while time.time() - start < args.duration:
+        while time.time() - start < scaled_duration:
             model.learn(total_timesteps=args.timesteps, reset_num_timesteps=False, callback=callbacks)
 
         # Start new episode and swap training agent automatically


### PR DESCRIPTION
## Summary
- adjust training time limit using `speed_multiplier`
- document that `--duration` is environment time and timer scales with `--speed-multiplier`

## Testing
- `python -m py_compile *.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862983bc2f08327b90f6869d0ecc8ac