### PR TITLE
Fix training duration scaling

### DIFF
--- a/train.py
+++ b/train.py
@@ -96,7 +96,8 @@ def run_selfplay(args: argparse.Namespace) -> None:
         env.set_run_info(ep, args.episodes)
         import time
         scaled_duration = args.duration / args.speed_multiplier
-        env.set_training_end_time(time.time() + scaled_duration)
+        start = time.time()
+        env.set_training_end_time(start + scaled_duration)
         obs, _ = env.reset()
         oni_obs, nige_obs = obs
         oni_log_probs = []
@@ -104,7 +105,7 @@ def run_selfplay(args: argparse.Namespace) -> None:
         oni_rewards = []
         nige_rewards = []
         done = False
-        while not done:
+        while not done and time.time() - start < scaled_duration:
             oni_action, oni_logp = oni_policy.act(torch.tensor(oni_obs, dtype=torch.float32))
             nige_action, nige_logp = nige_policy.act(torch.tensor(nige_obs, dtype=torch.float32))
             (oni_obs, nige_obs), (r_o, r_n), terminated, truncated, _ = env.step((


### PR DESCRIPTION
## Summary
- ensure `train.py` honours `--speed-multiplier` when using `--duration`

## Testing
- `python -m py_compile train.py`
- `python -m py_compile evaluate.py gym_tag_env.py tag_game.py episode_swap_env.py stage_generator.py`
- `python train.py --episodes 1 --timesteps 1 --duration 1 --speed-multiplier 2` *(fails: pkg_resources warning)*

------
https://chatgpt.com/codex/tasks/task_e_6862b22b88e483278b6153339d1ca68e