### PR TITLE
Fix reward scaling in tag env

### DIFF
--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -132,8 +132,6 @@ class MultiTagEnv(gym.Env):
                 nige_reward = 1.0
             else:
                 nige_reward = 0.0
-        oni_reward *= self.speed_multiplier
-        nige_reward *= self.speed_multiplier
 
         self.last_rewards = (oni_reward, nige_reward)
         self.cumulative_rewards[0] += oni_reward
@@ -294,7 +292,6 @@ class TagEnv(gym.Env):
             reward = 1.0 + remain_ratio
         else:
             reward = -0.01
-        reward *= self.speed_multiplier
         self.last_reward = reward
         self.cumulative_reward += reward
         info = {}


### PR DESCRIPTION
## Summary
- don't multiply rewards by speed multiplier so that episode rewards remain consistent regardless of update rate

## Testing
- `python -m py_compile gym_tag_env.py tag_game.py stage_generator.py episode_swap_env.py train.py evaluate.py`


------
https://chatgpt.com/codex/tasks/task_e_6862bf725514832792be1bc57956a949