### PR TITLE
Switch evaluation to PyTorch policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,14 @@ py train.py --episodes 1000 --render
 | `--lr <float>` | 自作ポリシー勾配用の学習率 | 3e-4 |
 | `--g` | GPU を利用する(利用可能な場合) | - |
 
+学習済み `.pth` ファイルを読み込み、`train.py` と同じ `Policy` ネットワークで行動を計算します。
+
 ### `evaluate.py`
 
 | オプション | 説明 | デフォルト |
 |------------|------|-----------|
-| `--oni-model <path>` | 評価用鬼モデルのパス | `oni_policy.zip` |
-| `--nige-model <path>` | 評価用逃げモデルのパス | `nige_policy.zip` |
+| `--oni-model <path>` | 評価用鬼モデルのパス | `oni_selfplay.pth` |
+| `--nige-model <path>` | 評価用逃げモデルのパス | `nige_selfplay.pth` |
 | `--episodes <int>` | 評価エピソード数 | 10 |
 | `--render` | 描画を有効化 | - |
 | `--speed-multiplier <float>` | 環境の処理速度倍率 | 1.0 |


### PR DESCRIPTION
## Summary
- rewrite `evaluate.py` to load `.pth` models using the Policy network from `train.py`
- update README to reflect PyTorch-based evaluation

## Testing
- `python -m py_compile evaluate.py train.py gym_tag_env.py stage_generator.py tag_game.py episode_swap_env.py`

------
https://chatgpt.com/codex/tasks/task_e_6863444ffc748327b4699666196db6c5