### PR TITLE
Fix MultiTagEnv observation space

### DIFF
--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -39,8 +39,8 @@ class MultiTagEnv(gym.Env):
         self.stage: StageMap | None = None
         self.oni: Agent | None = None
         self.nige: Agent | None = None
-        low = np.array([-width, -height, 0], dtype=np.float32)
-        high = np.array([width, height, 1], dtype=np.float32)
+        low = np.array([-width, -height], dtype=np.float32)
+        high = np.array([width, height], dtype=np.float32)
         self.observation_space = spaces.Box(low=low, high=high, dtype=np.float32)
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
         self.step_count = 0


### PR DESCRIPTION
## Summary
- 修正: `MultiTagEnv` の `observation_space` を2次元のBoxに変更

## Testing
- `python -m py_compile *.py`
- `python - <<'EOF'
from gym_tag_env import MultiTagEnv
env = MultiTagEnv()
print('shape', env.observation_space.shape, 'low', env.observation_space.low, 'high', env.observation_space.high)
EOF`
- `python - <<'EOF'
from gym_tag_env import MultiTagEnv
env = MultiTagEnv()
obs,_ = env.reset(seed=42)
actions = (env.action_space.sample(), env.action_space.sample())
next_obs, rewards, done, trunc, info = env.step(actions)
print('next lens', len(next_obs[0]), len(next_obs[1]))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6863f2119a10832792d8df5261d82d20