### PR TITLE
Selfplay timing overhaul

### DIFF
--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -96,11 +96,14 @@ class MultiTagEnv(gym.Env):
         assert self.oni and self.nige and self.stage
         action_oni, action_nige = actions
         self.step_count += 1
+        truncated_by_time = False
         if self.training_end_time is not None:
+            now = time.time()
             self.remaining_time = max(
                 0.0,
-                (self.training_end_time - time.time()) * self.speed_multiplier,
+                (self.training_end_time - now) * self.speed_multiplier,
             )
+            truncated_by_time = now >= self.training_end_time
 
         odx, ody = float(action_oni[0]), float(action_oni[1])
         ndx, ndy = float(action_nige[0]), float(action_nige[1])
@@ -120,7 +123,7 @@ class MultiTagEnv(gym.Env):
         )
 
         terminated = self.oni.collides_with(self.nige)
-        truncated = self.step_count >= self.max_steps
+        truncated = self.step_count >= self.max_steps or truncated_by_time
 
         if terminated:
             remain_ratio = (self.max_steps - self.step_count) / self.max_steps
@@ -267,11 +270,14 @@ class TagEnv(gym.Env):
     def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, bool, dict]:
         assert self.oni and self.nige and self.stage
         self.step_count += 1
+        truncated_by_time = False
         if self.training_end_time is not None:
+            now = time.time()
             self.remaining_time = max(
                 0.0,
-                (self.training_end_time - time.time()) * self.speed_multiplier,
+                (self.training_end_time - now) * self.speed_multiplier,
             )
+            truncated_by_time = now >= self.training_end_time
         dx, dy = float(action[0]), float(action[1])
         self.oni.set_direction(dx, dy)
         # random policy for escapee
@@ -286,7 +292,7 @@ class TagEnv(gym.Env):
             self.oni.observe(self.nige, self.stage), dtype=np.float32
         )
         terminated = self.oni.collides_with(self.nige)
-        truncated = self.step_count >= self.max_steps
+        truncated = self.step_count >= self.max_steps or truncated_by_time
         if terminated:
             remain_ratio = (self.max_steps - self.step_count) / self.max_steps
             reward = 1.0 + remain_ratio

--- a/train.py
+++ b/train.py
@@ -80,8 +80,7 @@ def run_selfplay(args: argparse.Namespace) -> None:
         env.set_run_info(ep, args.episodes)
         import time
         scaled_duration = args.duration / args.speed_multiplier
-        start = time.time()
-        env.set_training_end_time(start + scaled_duration)
+        env.set_training_end_time(time.time() + scaled_duration)
         obs, _ = env.reset()
         oni_obs, nige_obs = obs
         oni_log_probs = []
@@ -89,7 +88,7 @@ def run_selfplay(args: argparse.Namespace) -> None:
         oni_rewards = []
         nige_rewards = []
         done = False
-        while not done and time.time() - start < scaled_duration:
+        while not done:
             oni_action, oni_logp = oni_policy.act(
                 torch.tensor(oni_obs, dtype=torch.float32, device=device)
             )


### PR DESCRIPTION
## Summary
- manage training time inside `MultiTagEnv.step`
- stop training loop only when episode terminates or truncates

## Testing
- `python -m py_compile gym_tag_env.py train.py evaluate.py episode_swap_env.py stage_generator.py tag_game.py`
- `python train.py --episodes 12 --duration 1 --speed-multiplier 1`
- `python train.py --episodes 1 --duration 1 --speed-multiplier 2`


------
https://chatgpt.com/codex/tasks/task_e_6863f2168f8883278c181cecedb2a50f