### PR TITLE
Use env.set_run_info in evaluation

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -70,9 +70,8 @@ def main():
 
     rewards: List[Tuple[float, float]] = []
     for i in range(args.episodes):
-        env.current_run = i + 1
-        env.total_runs = args.episodes
-        env.remaining_time = 0.0
+        env.set_run_info(i + 1, args.episodes)
+        env.set_training_end_time(None)
         rewards.append(run_episode(env, oni_model, nige_model, device, args.render))
 
     env.close()


### PR DESCRIPTION
## Summary
- don't update env attributes directly when evaluating
- explicitly reset training end time

## Testing
- `python -m py_compile evaluate.py`


------
https://chatgpt.com/codex/tasks/task_e_6863f2168df4832799f9c8605192d78d