### PR TITLE
観測ベクトルに距離情報を追加

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -61,10 +61,11 @@ def main():
     print(f"Using device: {device}")
 
     env = MultiTagEnv(speed_multiplier=args.speed_multiplier)
-    oni_model = Policy().to(device)
+    input_dim = env.observation_space.shape[0]
+    oni_model = Policy(input_dim=input_dim).to(device)
     oni_model.load_state_dict(torch.load(args.oni_model, map_location=device))
     oni_model.eval()
-    nige_model = Policy().to(device)
+    nige_model = Policy(input_dim=input_dim).to(device)
     nige_model.load_state_dict(torch.load(args.nige_model, map_location=device))
     nige_model.eval()
 

--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -39,8 +39,8 @@ class MultiTagEnv(gym.Env):
         self.stage: StageMap | None = None
         self.oni: Agent | None = None
         self.nige: Agent | None = None
-        low = np.array([-width, -height], dtype=np.float32)
-        high = np.array([width, height], dtype=np.float32)
+        low = np.array([-1.0, -1.0, 0.0], dtype=np.float32)
+        high = np.array([1.0, 1.0, 1.0], dtype=np.float32)
         self.observation_space = spaces.Box(low=low, high=high, dtype=np.float32)
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
         self.step_count = 0
@@ -219,8 +219,8 @@ class TagEnv(gym.Env):
         self.stage: StageMap | None = None
         self.oni: Agent | None = None
         self.nige: Agent | None = None
-        low = np.array([-width, -height], dtype=np.float32)
-        high = np.array([width, height], dtype=np.float32)
+        low = np.array([-1.0, -1.0, 0.0], dtype=np.float32)
+        high = np.array([1.0, 1.0, 1.0], dtype=np.float32)
         self.observation_space = spaces.Box(low=low, high=high, dtype=np.float32)
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
         self.step_count = 0

--- a/tag_game.py
+++ b/tag_game.py
@@ -131,6 +131,28 @@ class StageMap:
             direction = direction.normalize()
         return direction
 
+    def shortest_path_info(
+        self, start: pygame.Vector2, goal: pygame.Vector2
+    ) -> tuple[pygame.Vector2, int]:
+        """Return direction and path length from ``start`` to ``goal``.
+
+        経路が存在しない場合は方向ベクトル(0,0)と距離0を返す。"""
+
+        path = self.shortest_path(start, goal)
+        if not path:
+            return pygame.Vector2(0, 0), 0
+
+        if len(path) < 2:
+            direction = pygame.Vector2(0, 0)
+        else:
+            dx = path[1][0] - path[0][0]
+            dy = path[1][1] - path[0][1]
+            direction = pygame.Vector2(dx, dy)
+            if direction.length_squared() > 0:
+                direction = direction.normalize()
+        distance = len(path) - 1
+        return direction, distance
+
     def draw(self, screen: pygame.Surface, offset: Tuple[int, int] = (0, 0)) -> None:
         wall_color = (40, 40, 40)
         floor_color = (200, 200, 200)
@@ -241,10 +263,13 @@ class Agent:
 
         if stage is None:
             diff = other.pos - self.pos
-            return [diff.x, diff.y]
+            distance = diff.length()
+            return [diff.x, diff.y, distance]
 
-        direction = stage.shortest_path_direction(self.pos, other.pos)
-        return [direction.x, direction.y]
+        direction, length = stage.shortest_path_info(self.pos, other.pos)
+        max_dist = stage.width + stage.height
+        dist_norm = min(length / max_dist, 1.0)
+        return [direction.x, direction.y, dist_norm]
 
 
 def get_state(

--- a/train.py
+++ b/train.py
@@ -32,7 +32,7 @@ def _create_env(args: argparse.Namespace) -> MultiTagEnv:
     """Create :class:`MultiTagEnv` with the specified speed."""
     return MultiTagEnv(speed_multiplier=args.speed_multiplier)
 class Policy(nn.Module):
-    def __init__(self, input_dim: int = 2, hidden_dim: int = 64, output_dim: int = 2):
+    def __init__(self, input_dim: int = 3, hidden_dim: int = 64, output_dim: int = 2):
         super().__init__()
         self.net = nn.Sequential(
             nn.Linear(input_dim, hidden_dim),
@@ -71,8 +71,9 @@ def run_selfplay(args: argparse.Namespace) -> None:
     print(f"Using device: {device}")
 
     env = _create_env(args)
-    oni_policy = Policy().to(device)
-    nige_policy = Policy().to(device)
+    input_dim = env.observation_space.shape[0]
+    oni_policy = Policy(input_dim=input_dim).to(device)
+    nige_policy = Policy(input_dim=input_dim).to(device)
     oni_optim = optim.Adam(oni_policy.parameters(), lr=args.lr)
     nige_optim = optim.Adam(nige_policy.parameters(), lr=args.lr)
 


### PR DESCRIPTION
## Summary
- `StageMap` に最短経路方向と距離を返す `shortest_path_info` を追加
- `Agent.observe` が距離(正規化)を含む3要素ベクトルを返すよう変更
- 環境の `observation_space` を [-1,-1,0]-[1,1,1] に拡張
- ポリシーネットワークの入力次元を環境に合わせて自動設定

## Testing
- `python -m py_compile tag_game.py gym_tag_env.py episode_swap_env.py train.py evaluate.py stage_generator.py`
- `python - <<'PY'
import gym_tag_env
env=gym_tag_env.MultiTagEnv(); obs,_=env.reset(); print(len(obs[0]), obs[0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6863f56a00388327b1f44119875fde9f