### PR TITLE
Add shortest path vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ py tag_game.py
 
 また、強化学習向けには `gym_tag_env.py` に `MultiTagEnv` クラスを実装しています。`reset()` でステージとエージェントを再初期化し、`step()` では鬼と逃げのアクションをタプルで与え、観測と報酬も `(鬼, 逃げ)` のタプルで返されます。初期位置は毎回ランダムに選ばれ、必要に応じて `start_distance_range` で互いの距離を制約できます。逃げ側の報酬は捕まったら `-1`、時間いっぱい逃げ切ったら `+1` です。
 
+`StageMap` クラスには壁を考慮した最短経路探索 `shortest_path` が用意されています。
+その経路を構成する方向ベクトル列を取得するには `shortest_path_vectors` を利用します。
+
+```python
+stage = StageMap(31, 21)
+start = pygame.Vector2(1, 1)
+goal = pygame.Vector2(10, 10)
+vectors = stage.shortest_path_vectors(start, goal)
+```
+
 ## 学習
 
 以下のコマンドで必要なライブラリをインストールしてください。

--- a/tag_game.py
+++ b/tag_game.py
@@ -165,6 +165,28 @@ class StageMap:
         distance = len(path) - 1
         return direction, distance
 
+    def shortest_path_vectors(
+        self, start: pygame.Vector2, goal: pygame.Vector2
+    ) -> list[pygame.Vector2]:
+        """Return step vectors along the shortest path.
+
+        ``shortest_path`` で得られるセル座標列から、各ステップの方向ベクトル
+        (長さ1) を作成し、順番に並べたリストを返す。経路が存在しない場合は
+        空リストを返す。
+        """
+
+        path = self.shortest_path(start, goal)
+        if len(path) < 2:
+            return []
+
+        vectors: list[pygame.Vector2] = []
+        for (x0, y0), (x1, y1) in zip(path[:-1], path[1:]):
+            vec = pygame.Vector2(x1 - x0, y1 - y0)
+            if vec.length_squared() > 0:
+                vec = vec.normalize()
+            vectors.append(vec)
+        return vectors
+
     def draw(self, screen: pygame.Surface, offset: Tuple[int, int] = (0, 0)) -> None:
         wall_color = (40, 40, 40)
         floor_color = (200, 200, 200)


### PR DESCRIPTION
## Summary
- enable shortest path retrieval as a sequence of vectors
- document `StageMap.shortest_path_vectors` usage in README

## Testing
- `python -m py_compile tag_game.py stage_generator.py gym_tag_env.py evaluate.py train.py episode_swap_env.py`

------
https://chatgpt.com/codex/tasks/task_e_6863ff1c10f8832787118d0562dfebf6