### PR TITLE
Visualize wall-aware path using vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ python3 stage_generator.py --width 31 --height 21
 ```bash
 py tag_game.py
 ```
+実行すると、鬼から逃げまでの経路が `shortest_path_vectors` を用いて計算され、
+壁を回避した最短経路が緑色の線で表示されます。
 
 また、強化学習向けには `gym_tag_env.py` に `MultiTagEnv` クラスを実装しています。`reset()` でステージとエージェントを再初期化し、`step()` では鬼と逃げのアクションをタプルで与え、観測と報酬も `(鬼, 逃げ)` のタプルで返されます。初期位置は毎回ランダムに選ばれ、必要に応じて `start_distance_range` で互いの距離を制約できます。逃げ側の報酬は捕まったら `-1`、時間いっぱい逃げ切ったら `+1` です。
 

--- a/tag_game.py
+++ b/tag_game.py
@@ -187,6 +187,50 @@ class StageMap:
             vectors.append(vec)
         return vectors
 
+    def draw_shortest_path_vectors(
+        self,
+        screen: pygame.Surface,
+        start: pygame.Vector2,
+        goal: pygame.Vector2,
+        *,
+        color: Tuple[int, int, int] = (0, 255, 0),
+        offset: Tuple[int, int] = (0, 0),
+    ) -> None:
+        """Draw the shortest path from ``start`` to ``goal``.
+
+        Parameters
+        ----------
+        screen : pygame.Surface
+            Surface to draw on.
+        start : pygame.Vector2
+            Starting position (world coordinates).
+        goal : pygame.Vector2
+            Goal position (world coordinates).
+        color : Tuple[int, int, int], optional
+            Line color, by default green.
+        offset : Tuple[int, int], optional
+            Pixel offset for drawing, by default ``(0, 0)``.
+        """
+
+        vectors = self.shortest_path_vectors(start, goal)
+        if not vectors:
+            return
+
+        off_x, off_y = offset
+        pos = pygame.Vector2(int(start.x) + 0.5, int(start.y) + 0.5)
+        prev_px = (
+            off_x + pos.x * CELL_SIZE,
+            off_y + pos.y * CELL_SIZE,
+        )
+        for vec in vectors:
+            pos += vec
+            next_px = (
+                off_x + pos.x * CELL_SIZE,
+                off_y + pos.y * CELL_SIZE,
+            )
+            pygame.draw.line(screen, color, prev_px, next_px, 2)
+            prev_px = next_px
+
     def draw(self, screen: pygame.Surface, offset: Tuple[int, int] = (0, 0)) -> None:
         wall_color = (40, 40, 40)
         floor_color = (200, 200, 200)
@@ -371,18 +415,8 @@ def main():
         stage.draw(screen, offset)
         oni.draw(screen, offset)
         nige.draw(screen, offset)
-        pygame.draw.line(
-            screen,
-            (255, 0, 0),
-            (
-                int(oni.pos.x * CELL_SIZE + CELL_SIZE / 2) + offset[0],
-                int(oni.pos.y * CELL_SIZE + CELL_SIZE / 2) + offset[1],
-            ),
-            (
-                int(nige.pos.x * CELL_SIZE + CELL_SIZE / 2) + offset[0],
-                int(nige.pos.y * CELL_SIZE + CELL_SIZE / 2) + offset[1],
-            ),
-            2,
+        stage.draw_shortest_path_vectors(
+            screen, oni.pos, nige.pos, offset=offset
         )
         txt = font.render(f"残り{remaining:.1f}秒", True, (0, 0, 0))
         screen.blit(txt, (10, 5))


### PR DESCRIPTION
## Summary
- add `StageMap.draw_shortest_path_vectors` to show the shortest path between two points
- use this path visualization in `tag_game.py`
- update README to mention the new default behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68640165079083279d7bf17af2d21900