### PR TITLE
Fix shortest path visualization for training

### DIFF
--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -194,18 +194,11 @@ class MultiTagEnv(gym.Env):
         self.stage.draw(self.screen, offset)
         self.oni.draw(self.screen, offset)
         self.nige.draw(self.screen, offset)
-        pygame.draw.line(
+        self.stage.draw_shortest_path_vectors(
             self.screen,
-            (255, 0, 0),
-            (
-                int(self.oni.pos.x * CELL_SIZE + CELL_SIZE / 2) + offset[0],
-                int(self.oni.pos.y * CELL_SIZE + CELL_SIZE / 2) + offset[1],
-            ),
-            (
-                int(self.nige.pos.x * CELL_SIZE + CELL_SIZE / 2) + offset[0],
-                int(self.nige.pos.y * CELL_SIZE + CELL_SIZE / 2) + offset[1],
-            ),
-            2,
+            self.oni.pos,
+            self.nige.pos,
+            offset=offset,
         )
         font = pygame.font.SysFont(None, 24)
         txt_time = font.render(
@@ -378,18 +371,11 @@ class TagEnv(gym.Env):
         self.stage.draw(self.screen, offset)
         self.oni.draw(self.screen, offset)
         self.nige.draw(self.screen, offset)
-        pygame.draw.line(
+        self.stage.draw_shortest_path_vectors(
             self.screen,
-            (255, 0, 0),
-            (
-                int(self.oni.pos.x * CELL_SIZE + CELL_SIZE / 2) + offset[0],
-                int(self.oni.pos.y * CELL_SIZE + CELL_SIZE / 2) + offset[1],
-            ),
-            (
-                int(self.nige.pos.x * CELL_SIZE + CELL_SIZE / 2) + offset[0],
-                int(self.nige.pos.y * CELL_SIZE + CELL_SIZE / 2) + offset[1],
-            ),
-            2,
+            self.oni.pos,
+            self.nige.pos,
+            offset=offset,
         )
         font = pygame.font.SysFont(None, 24)
         txt_time = font.render(


### PR DESCRIPTION
## Summary
- use shortest_path_vectors in MultiTagEnv and TagEnv renderers

## Testing
- `python -m py_compile gym_tag_env.py tag_game.py train.py evaluate.py stage_generator.py episode_swap_env.py gym_tag_env.py`

------
https://chatgpt.com/codex/tasks/task_e_6864040c444c832799cd70a4d27b2de8