### PR TITLE
Fix timer display in training

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import re
+import time
 
 import gymnasium as gym
 import torch
@@ -98,7 +99,7 @@ def run_selfplay(args: argparse.Namespace) -> None:
 
     for ep in range(1, args.episodes + 1):
         env.set_run_info(ep, args.episodes)
-        env.set_training_end_time(None)
+        env.set_training_end_time(time.time() + args.duration)
         obs, _ = env.reset()
         oni_obs, nige_obs = obs
         oni_log_probs = []


### PR DESCRIPTION
## Summary
- correctly initialize the episode timer in `train.py`
- import `time` for countdown logic

## Testing
- `python -m py_compile train.py`


------
https://chatgpt.com/codex/tasks/task_e_686403cceb608327831b1eb0ab41c03e