### PR TITLE
Fix duration-based termination

### DIFF
--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -148,7 +148,8 @@ class MultiTagEnv(gym.Env):
         )
 
         terminated = self.oni.collides_with(self.nige)
-        truncated_by_steps = self.physical_step_count >= self.max_steps
+        use_step_limit = self.training_end_time is None
+        truncated_by_steps = use_step_limit and self.physical_step_count >= self.max_steps
         truncated = truncated_by_steps or truncated_by_time
 
         if terminated:
@@ -336,7 +337,8 @@ class TagEnv(gym.Env):
             self.oni.observe(self.nige, self.stage), dtype=np.float32
         )
         terminated = self.oni.collides_with(self.nige)
-        truncated_by_steps = self.physical_step_count >= self.max_steps
+        use_step_limit = self.training_end_time is None
+        truncated_by_steps = use_step_limit and self.physical_step_count >= self.max_steps
         truncated = truncated_by_steps or truncated_by_time
         if terminated:
             remain_ratio = (self.max_steps - self.step_count) / self.max_steps


### PR DESCRIPTION
## Summary
- fix early termination when training_end_time is set

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686405ff0a348327af72213e6169678f