### PR TITLE
Use class variable for physical step updates

### DIFF
--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -131,7 +131,7 @@ class MultiTagEnv(gym.Env):
 
         _, prev_dist = self.stage.shortest_path_info(self.oni.pos, self.nige.pos)
 
-        updates = max(1, int(round(self.speed_multiplier)))
+        updates = self._updates_per_step
 
         for _ in range(updates):
             self.oni.update(self.stage)
@@ -335,7 +335,7 @@ class TagEnv(gym.Env):
         self.nige.set_direction(float(rnd[0]), float(rnd[1]))
 
         _, prev_dist = self.stage.shortest_path_info(self.oni.pos, self.nige.pos)
-        updates = max(1, int(round(self.speed_multiplier)))
+        updates = self._updates_per_step
         for _ in range(updates):
             self.oni.update(self.stage)
             self.nige.update(self.stage)


### PR DESCRIPTION
## Summary
- use `_updates_per_step` consistently in both environments
- run `py_compile` to confirm no syntax errors

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6864178bd7b8832785a2be5a0dbe70e6