### PR TITLE
Add render_speed option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ py train.py --episodes 1000 --render
 ```
 
 描画更新間隔は `--render-interval` で指定できます (デフォルト1ステップごと)。
-学習時間を秒単位で制限したい場合は `--duration` を用います。環境の描画速度を調整する `--speed-multiplier` オプションも利用可能です。内部的には行動更新をこの倍率分だけ繰り返すため、値を大きくするほど高速に進行しますが、計算負荷によっては指定倍率通りにならないことがあります。`--duration` で指定した値は環境時間なので、`--speed-multiplier` が 2 の場合、実際の経過時間は `duration / speed-multiplier` となります。
+学習時間を秒単位で制限したい場合は `--duration` を用います。物理更新の倍率は `--speed-multiplier`、描画フレームレートは `--render-speed` でそれぞれ制御できます。`--speed-multiplier` を大きくすると 1 ステップあたりの内部更新回数が増え、計算負荷によっては指定倍率通りにならないことがあります。`--duration` で指定した値は環境時間なので、`--speed-multiplier` が 2 の場合、実際の経過時間は `duration / speed_multiplier` となります。
 学習処理は `run_selfplay` 関数として実装されており、保存したモデルは `evaluate.py` を通じて同じネットワーク構造で評価できます。
 
 学習後、鬼側モデルは `oni_selfplay.pth`、逃げ側モデルは `nige_selfplay.pth` として保存されます。
@@ -88,6 +88,7 @@ py train.py --episodes 1000 --render
 | `--duration <秒>` | 各エピソードの学習時間（環境時間） | 10 |
 | `--episodes <int>` | 総エピソード数 | 10 |
 | `--speed-multiplier <float>` | 環境の処理速度倍率（タイマーも連動） | 1.0 |
+| `--render-speed <float>` | 描画FPSの倍率 | 1.0 |
 | `--gamma <float>` | 自作ポリシー勾配用の割引率 | 0.99 |
 | `--lr <float>` | 自作ポリシー勾配用の学習率 | 3e-4 |
 | `--g` | GPU を利用する(利用可能な場合) | - |
@@ -103,6 +104,7 @@ py train.py --episodes 1000 --render
 | `--episodes <int>` | 評価エピソード数 | 10 |
 | `--render` | 描画を有効化 | - |
 | `--speed-multiplier <float>` | 環境の処理速度倍率 | 1.0 |
+| `--render-speed <float>` | 描画FPSの倍率 | 1.0 |
 | `--g` | GPU を利用する(利用可能な場合) | - |
 
 ## ライセンス

--- a/evaluate.py
+++ b/evaluate.py
@@ -16,6 +16,7 @@ def parse_args():
     parser.add_argument("--episodes", type=int, default=10, help="Number of episodes")
     parser.add_argument("--render", action="store_true", help="Render environment")
     parser.add_argument("--speed-multiplier", type=float, default=1.0, help="Environment speed multiplier")
+    parser.add_argument("--render-speed", type=float, default=1.0, help="Rendering speed multiplier")
     parser.add_argument("--g", action="store_true", help="Use GPU if available")
     return parser.parse_args()
 
@@ -60,7 +61,10 @@ def main():
         print("GPU is not available. Falling back to CPU.")
     print(f"Using device: {device}")
 
-    env = MultiTagEnv(speed_multiplier=args.speed_multiplier)
+    env = MultiTagEnv(
+        speed_multiplier=args.speed_multiplier,
+        render_speed=args.render_speed,
+    )
     input_dim = env.observation_space.shape[0]
     oni_model = Policy(input_dim=input_dim).to(device)
     oni_model.load_state_dict(torch.load(args.oni_model, map_location=device))

--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -30,6 +30,7 @@ class MultiTagEnv(gym.Env):
         max_steps: int = 500,
         extra_wall_prob: float = 0.0,
         speed_multiplier: float = 1.0,
+        render_speed: float = 1.0,
         start_distance_range: tuple[int, int] | None = None,
     ) -> None:
         super().__init__()
@@ -48,6 +49,7 @@ class MultiTagEnv(gym.Env):
         self.physical_step_count = 0
         self.speed_multiplier = max(0.1, speed_multiplier)
         self._updates_per_step = max(1, int(round(self.speed_multiplier)))
+        self.render_speed = max(0.1, render_speed)
         self.screen: pygame.Surface | None = None
         self.clock: pygame.time.Clock | None = None
         self.cumulative_rewards: list[float] = [0.0, 0.0]
@@ -226,7 +228,7 @@ class MultiTagEnv(gym.Env):
         self.screen.blit(txt_reward, (10, 25))
         pygame.display.flip()
         if self.clock:
-            self.clock.tick(60 * self.speed_multiplier)
+            self.clock.tick(60 * self.render_speed)
 
 
 
@@ -240,6 +242,7 @@ class TagEnv(gym.Env):
         max_steps: int = 500,
         extra_wall_prob: float = 0.0,
         speed_multiplier: float = 1.0,
+        render_speed: float = 1.0,
         start_distance_range: tuple[int, int] | None = None,
     ):
         super().__init__()
@@ -258,6 +261,7 @@ class TagEnv(gym.Env):
         self.physical_step_count = 0
         self.speed_multiplier = max(0.1, speed_multiplier)
         self._updates_per_step = max(1, int(round(self.speed_multiplier)))
+        self.render_speed = max(0.1, render_speed)
         self.screen: pygame.Surface | None = None
         self.clock: pygame.time.Clock | None = None
         self.remaining_time: float = 0.0
@@ -411,7 +415,7 @@ class TagEnv(gym.Env):
         self.screen.blit(txt_reward, (10, 25))
         pygame.display.flip()
         if self.clock:
-            self.clock.tick(60 * self.speed_multiplier)
+            self.clock.tick(60 * self.render_speed)
 
     def close(self) -> None:
         if self.screen:

--- a/train.py
+++ b/train.py
@@ -24,6 +24,7 @@ def parse_args():
     parser.add_argument("--duration", type=int, default=10, help="Training duration per episode in seconds")
     parser.add_argument("--episodes", type=int, default=10, help="Number of episodes")
     parser.add_argument("--speed-multiplier", type=float, default=1.0, help="Environment speed multiplier")
+    parser.add_argument("--render-speed", type=float, default=1.0, help="Rendering speed multiplier")
     parser.add_argument("--gamma", type=float, default=0.99, help="Discount factor for self-play")
     parser.add_argument("--lr", type=float, default=3e-4, help="Learning rate for self-play")
     parser.add_argument("--entropy-coeff", type=float, default=0.01, help="Entropy regularization coefficient")
@@ -33,7 +34,10 @@ def parse_args():
 
 def _create_env(args: argparse.Namespace) -> MultiTagEnv:
     """Create :class:`MultiTagEnv` with the specified speed."""
-    return MultiTagEnv(speed_multiplier=args.speed_multiplier)
+    return MultiTagEnv(
+        speed_multiplier=args.speed_multiplier,
+        render_speed=args.render_speed,
+    )
 class Policy(nn.Module):
     def __init__(self, input_dim: int = 3, hidden_dim: int = 64, output_dim: int = 2):
         super().__init__()


### PR DESCRIPTION
## Summary
- allow specifying `render_speed` for `MultiTagEnv` and `TagEnv`
- control FPS via command line in train/evaluate
- document the new option in README

## Testing
- `python -m py_compile gym_tag_env.py train.py evaluate.py`

------
https://chatgpt.com/codex/tasks/task_e_6864290d9a00832797628e0d3447c643