### PR TITLE
Remove unused timesteps option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ py train.py --episodes 1000 --render
 
 | オプション | 説明 | デフォルト |
 |------------|------|-----------|
-| `--timesteps <int>` | 各エピソードの学習ステップ数 | 10000 |
 | `--oni-model <path>` | 鬼モデルの保存/読み込みパス | `oni_policy.zip` |
 | `--nige-model <path>` | 逃げモデルの保存/読み込みパス | `nige_policy.zip` |
 | `--checkpoint-freq <int>` | 指定間隔でチェックポイント保存 | 0 |
@@ -103,7 +102,6 @@ py train.py --episodes 1000 --render
 
 | オプション | 説明 | デフォルト |
 |------------|------|-----------|
-| `--timesteps <int>` | 各エピソードの学習ステップ数 | 10000 |
 | `--oni-model <path>` | 鬼モデルの保存/読み込みパス | `oni_sac.pth` |
 | `--nige-model <path>` | 逃げモデルの保存/読み込みパス | `nige_sac.pth` |
 | `--checkpoint-freq <int>` | 指定間隔でチェックポイント保存 | 0 |

--- a/train.py
+++ b/train.py
@@ -15,7 +15,6 @@ from gym_tag_env import MultiTagEnv
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Train agents for TagEnv")
-    parser.add_argument("--timesteps", type=int, default=10000, help="Training steps per episode")
     parser.add_argument("--oni-model", type=str, default="oni_policy.zip", help="Path to save/load oni model")
     parser.add_argument("--nige-model", type=str, default="nige_policy.zip", help="Path to save/load nige model")
     parser.add_argument("--checkpoint-freq", type=int, default=0, help="Save checkpoints every N steps")

--- a/train_sac.py
+++ b/train_sac.py
@@ -17,7 +17,6 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Soft Actor-Critic training for MultiTagEnv"
     )
-    parser.add_argument("--timesteps", type=int, default=10000, help="Training steps per episode")
     parser.add_argument("--oni-model", type=str, default="oni_sac.pth", help="Path to save oni model")
     parser.add_argument("--nige-model", type=str, default="nige_sac.pth", help="Path to save nige model")
     parser.add_argument("--checkpoint-freq", type=int, default=0, help="Save checkpoints every N steps")


### PR DESCRIPTION
## Summary
- remove obsolete `--timesteps` option from training scripts
- delete corresponding documentation rows

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6864bae4144c8327917ff6701cc707a7