### PR TITLE
Fix GPU device mismatch in SAC agent

### DIFF
--- a/train_sac.py
+++ b/train_sac.py
@@ -104,7 +104,8 @@ class Actor(nn.Module):
         return y_t, log_prob
 
     def act(self, obs: np.ndarray) -> np.ndarray:
-        obs_t = torch.tensor(obs, dtype=torch.float32)
+        device = next(self.parameters()).device
+        obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
         with torch.no_grad():
             action, _ = self.sample(obs_t.unsqueeze(0))
         return action.squeeze(0).cpu().numpy()


### PR DESCRIPTION
## Summary
- ensure observations are moved to the same device as the model in `Actor.act`

## Testing
- `python train_sac.py --episodes 1 --duration 1 --g --render-interval 2 --speed-multiplier 0.5 --render-speed 0.5`

------
https://chatgpt.com/codex/tasks/task_e_6864c1fb2d708327983b2c650490223f