### PR TITLE
Fix device handling in SAC actor

### DIFF
--- a/train_sac.py
+++ b/train_sac.py
@@ -104,7 +104,8 @@ class Actor(nn.Module):
         return y_t, log_prob
 
     def act(self, obs: np.ndarray) -> np.ndarray:
-        obs_t = torch.tensor(obs, dtype=torch.float32)
+        device = next(self.parameters()).device
+        obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
         with torch.no_grad():
             action, _ = self.sample(obs_t.unsqueeze(0))
         return action.squeeze(0).cpu().numpy()


### PR DESCRIPTION
## Summary
- ensure `Actor.act` uses the same device as the model to build tensors
- confirm training works with `--g` option even when GPU is unavailable

## Testing
- `python train_sac.py --episodes 1 --duration 1 --g`

------
https://chatgpt.com/codex/tasks/task_e_6864e5f33f308327b8c94e02e3ec0a1e