### PR TITLE
Adjust model save directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ py train.py --episodes 1000 --render
 学習時間を秒単位で制限したい場合は `--duration` を用います。物理更新の倍率は `--speed-multiplier`、描画フレームレートは `--render-speed` でそれぞれ制御できます。`--speed-multiplier` を大きくすると 1 ステップあたりの内部更新回数が増え、計算負荷によっては指定倍率通りにならないことがあります。`--duration` で指定した値は環境時間なので、`--speed-multiplier` が 2 の場合、実際の経過時間は `duration / speed_multiplier` となります。
 学習処理は `run_selfplay` 関数として実装されており、保存したモデルは `evaluate.py` を通じて同じネットワーク構造で評価できます。
 
-学習後、鬼側モデルは `oni_selfplay.pth`、逃げ側モデルは `nige_selfplay.pth` として保存されます。
+学習後、鬼側モデルは `out/pytorch/oni/oni_YYYYMMDD_HHMMSS.pth`、逃げ側モデルは `out/pytorch/nige/nige_YYYYMMDD_HHMMSS.pth` のように日付と時刻を含むファイル名で保存されます。
 
 ## 旧 self-play スクリプト
 
@@ -115,6 +115,8 @@ py train.py --episodes 1000 --render
 | `--lr <float>` | 学習率 | 3e-4 |
 | `--g` | GPU を利用する(利用可能な場合) | - |
 
+`train_sac.py` で学習したモデルは、それぞれ `out/sac/oni/oni_YYYYMMDD_HHMMSS.pth` と `out/sac/nige/nige_YYYYMMDD_HHMMSS.pth` に保存されます。
+
 ### `evaluate.py`
 
 | オプション | 説明 | デフォルト |
@@ -126,6 +128,8 @@ py train.py --episodes 1000 --render
 | `--speed-multiplier <float>` | 環境の処理速度倍率 | 1.0 |
 | `--render-speed <float>` | 描画FPSの倍率 | 1.0 |
 | `--g` | GPU を利用する(利用可能な場合) | - |
+
+学習で生成されたモデルを評価する場合は、上記ディレクトリに保存されたファイルパスを `--oni-model` と `--nige-model` に指定してください。
 
 ## ライセンス
 

--- a/train.py
+++ b/train.py
@@ -71,20 +71,14 @@ def compute_returns(rewards, gamma: float):
     return returns
 
 
-def _next_output_path(base_dir: str, prefix: str) -> str:
-    """Return next sequential path like ``prefix_N.pth`` under ``base_dir``."""
+from datetime import datetime
+
+
+def _timestamp_output_path(base_dir: str, prefix: str) -> str:
+    """Return a path like ``prefix_YYYYMMDD_HHMMSS.pth`` under ``base_dir``."""
     os.makedirs(base_dir, exist_ok=True)
-    max_idx = 0
-    for name in os.listdir(base_dir):
-        if name.startswith(f"{prefix}_") and name.endswith(".pth"):
-            m = re.search(rf"{prefix}_(\d+)\.pth", name)
-            if m:
-                try:
-                    idx = int(m.group(1))
-                    max_idx = max(max_idx, idx)
-                except ValueError:
-                    continue
-    return os.path.join(base_dir, f"{prefix}_{max_idx + 1}.pth")
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return os.path.join(base_dir, f"{prefix}_{ts}.pth")
 
 
 def run_selfplay(args: argparse.Namespace) -> None:
@@ -175,8 +169,8 @@ def run_selfplay(args: argparse.Namespace) -> None:
                 f"episode {ep}: average oniR={avg_oni:.2f} average nigeR={avg_nige:.2f}"
             )
 
-    oni_path = _next_output_path("out/oni", "out")
-    nige_path = _next_output_path("out/nige", "nige")
+    oni_path = _timestamp_output_path("out/pytorch/oni", "oni")
+    nige_path = _timestamp_output_path("out/pytorch/nige", "nige")
     torch.save(oni_policy.state_dict(), oni_path)
     torch.save(nige_policy.state_dict(), nige_path)
     env.close()

--- a/train_sac.py
+++ b/train_sac.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from datetime import datetime
 from typing import Tuple
 
 import gymnasium as gym
@@ -40,6 +41,13 @@ def _create_env(args: argparse.Namespace) -> MultiTagEnv:
         speed_multiplier=args.speed_multiplier,
         render_speed=args.render_speed,
     )
+
+
+def _timestamp_output_path(base_dir: str, prefix: str) -> str:
+    """Return a path like ``prefix_YYYYMMDD_HHMMSS.pth`` under ``base_dir``."""
+    os.makedirs(base_dir, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return os.path.join(base_dir, f"{prefix}_{ts}.pth")
 
 
 class ReplayBuffer:
@@ -223,6 +231,9 @@ def run_training(args: argparse.Namespace) -> None:
     oni_buf = ReplayBuffer(args.buffer_size, obs_dim, action_dim)
     nige_buf = ReplayBuffer(args.buffer_size, obs_dim, action_dim)
 
+    final_oni_path = _timestamp_output_path("out/sac/oni", "oni")
+    final_nige_path = _timestamp_output_path("out/sac/nige", "nige")
+
     total_steps = 0
     for ep in range(1, args.episodes + 1):
         env.set_run_info(ep, args.episodes)
@@ -257,8 +268,8 @@ def run_training(args: argparse.Namespace) -> None:
             f"nige_reward={env.cumulative_rewards[1]:.2f}"
         )
 
-    oni.save(args.oni_model)
-    nige.save(args.nige_model)
+    oni.save(final_oni_path)
+    nige.save(final_nige_path)
     env.close()
 
 


### PR DESCRIPTION
## Summary
- timestamp output filenames with `_timestamp_output_path`
- save self-play models under `out/pytorch/oni|nige`
- save SAC models under `out/sac/oni|nige`
- document new save paths in README

## Testing
- `python -m py_compile train.py train_sac.py`
- `python train.py --episodes 1 --duration 1`
- `python train_sac.py --episodes 1 --duration 1`


------
https://chatgpt.com/codex/tasks/task_e_6864ed1aa25c83279a0711bbdf72ce25