### PR TITLE
Add model battle options to tag_game

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ py train_sac.py --episodes 1000 --render
 | `--duration <秒>` | 1ゲームの制限時間 | 10.0 |
 | `--width-range a,b` | 幅を[a,b]からランダムに奇数選択 | - |
 | `--height-range a,b` | 高さを[a,b]からランダムに奇数選択 | - |
+| `--games <int>` | 連続対戦数 | 1 |
+| `--oni <path>` | 鬼側モデルのパス（指定すると逃げはプレイヤー操作） | - |
+| `--nige <path>` | 逃げ側モデルのパス（指定すると鬼はプレイヤー操作） | - |
 
 ### `train_sac.py`
 


### PR DESCRIPTION
## Summary
- implement simple Actor network in tag_game so pretrained SAC models can be loaded
- add `--oni` / `--nige` options to play against a saved model
- allow multiple games via `--games` option and random stage size each match
- update README with the new options

## Testing
- `python -m py_compile tag_game.py`
- `python tag_game.py --oni dummy.pth --duration 0.1` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'dummy.pth')*

------
https://chatgpt.com/codex/tasks/task_e_6865397b18408327b45b24f73b7f6380