### PR TITLE
Implement sliding collisions for agents

### DIFF
--- a/tag_game.py
+++ b/tag_game.py
@@ -355,18 +355,27 @@ class Agent:
         radius = self.radius / CELL_SIZE
 
         new_x = self.pos.x + self.vel.x
-        if stage.collides_circle(new_x, self.pos.y, radius):
-            new_x = self.pos.x
-            self.vel.x = 0
-            self.speed_boost = 0.0
-
         new_y = self.pos.y + self.vel.y
-        if stage.collides_circle(new_x, new_y, radius):
-            new_y = self.pos.y
-            self.vel.y = 0
-            self.speed_boost = 0.0
 
-        self.pos.update(new_x, new_y)
+        if stage.collides_circle(new_x, new_y, radius):
+            # 角にぶつかった場合のスライド処理
+            if not stage.collides_circle(new_x, self.pos.y, radius):
+                # X 方向のみ移動可能
+                self.pos.x = new_x
+                self.vel.y = 0
+                self.speed_boost = 0.0
+            elif not stage.collides_circle(self.pos.x, new_y, radius):
+                # Y 方向のみ移動可能
+                self.pos.y = new_y
+                self.vel.x = 0
+                self.speed_boost = 0.0
+            else:
+                # 両方向とも衝突
+                self.vel.x = 0
+                self.vel.y = 0
+                self.speed_boost = 0.0
+        else:
+            self.pos.update(new_x, new_y)
 
     def draw(self, screen: pygame.Surface, offset: Tuple[int, int] = (0, 0)) -> None:
         off_x, off_y = offset


### PR DESCRIPTION
## Summary
- improve `Agent.update` with corner sliding logic

## Testing
- `python - <<'EOF'
import os
os.environ['SDL_VIDEODRIVER']='dummy'
from gym_tag_env import MultiTagEnv
env = MultiTagEnv(render_speed=0.1, speed_multiplier=0.1)
obs,_=env.reset(seed=0)
for _ in range(5):
    obs, reward, terminated, truncated, info = env.step((env.action_space.sample(), env.action_space.sample()))
print('done', obs[0].shape, reward)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68657a0b22b8832781ff9c6e2cc3d495