### PR TITLE
Add wall collision penalty

### DIFF
--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -145,9 +145,13 @@ class MultiTagEnv(gym.Env):
         _, prev_dist = self.stage.shortest_path_info(self.oni.pos, self.nige.pos)
 
         updates = max(1, int(round(self.speed_multiplier)))
+        oni_collisions = 0
+        nige_collisions = 0
         for _ in range(updates):
-            self.oni.update(self.stage)
-            self.nige.update(self.stage)
+            if self.oni.update(self.stage):
+                oni_collisions += 1
+            if self.nige.update(self.stage):
+                nige_collisions += 1
         self.physical_step_count += updates
 
         _, new_dist = self.stage.shortest_path_info(self.oni.pos, self.nige.pos)
@@ -182,6 +186,10 @@ class MultiTagEnv(gym.Env):
             else:
                 nige_reward = 0.0
             nige_reward += 0.01 * (-dist_delta) + 0.002 * updates
+
+        # small penalty for wall collisions
+        oni_reward -= 0.001 * oni_collisions
+        nige_reward -= 0.001 * nige_collisions
 
         # reward is computed for ``updates`` physical steps so that the
         # total reward does not shrink when ``speed_multiplier`` is large

--- a/tag_game.py
+++ b/tag_game.py
@@ -342,7 +342,9 @@ class Agent:
             self.dir = pygame.Vector2(0, 0)
             self.speed_boost = 0.0
 
-    def update(self, stage: StageMap) -> None:
+    def update(self, stage: StageMap) -> bool:
+        """Update agent position and return True if it collided with a wall."""
+        collided = False
         if self.dir.length_squared() > 0:
             accel = self.accel + self.speed_boost
             self.vel += self.dir * accel
@@ -358,6 +360,7 @@ class Agent:
         new_y = self.pos.y + self.vel.y
 
         if stage.collides_circle(new_x, new_y, radius):
+            collided = True
             # 角にぶつかった場合のスライド処理
             if not stage.collides_circle(new_x, self.pos.y, radius):
                 # X 方向のみ移動可能
@@ -376,7 +379,7 @@ class Agent:
                 self.speed_boost = 0.0
         else:
             self.pos.update(new_x, new_y)
-
+        return collided
     def draw(self, screen: pygame.Surface, offset: Tuple[int, int] = (0, 0)) -> None:
         off_x, off_y = offset
         pygame.draw.circle(


### PR DESCRIPTION
## Summary
- detect collisions in agent movement and let `update()` report them
- penalize each step spent colliding with a wall in `MultiTagEnv.step`

## Testing
- `python -m py_compile gym_tag_env.py tag_game.py stage_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_68657ecab7008327a50d32de4f7c8546