### PR TITLE
Improve escape rewards

### DIFF
--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -182,7 +182,8 @@ class MultiTagEnv(gym.Env):
         else:
             oni_reward = -0.005 * updates + 0.01 * dist_delta
             if truncated:
-                nige_reward = 1.0
+                nige_reward = 2.0
+                oni_reward -= 1.0
             else:
                 nige_reward = 0.0
             nige_reward += 0.01 * (-dist_delta) + 0.002 * updates


### PR DESCRIPTION
## Summary
- increase positive reward for escaping
- apply negative penalty to oni when the time limit is reached

## Testing
- `python3 -m py_compile gym_tag_env.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865cb64f8048327968ecc71170ba62b