### PR TITLE
Implement A* pathfinding and enlarge default map

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 ## ステージ生成
 
 ```bash
-python3 stage_generator.py --width 31 --height 21
+python3 stage_generator.py --width 255 --height 255
 ```
 
-実行すると固定サイズ（例: 31x21）のステージが標準出力に表示されます。
+実行すると固定サイズ（例: 255x255）のステージが標準出力に表示されます。
 `generate_stage` 関数に幅・高さを指定することで別サイズのステージも生成可能です。
 ステージには行き止まりが存在せず、孤立したエリアも生じないよう接続性を保ったまま生成されます。道幅はランダムで広げられます。
 壁密度を高めたい場合は `--extra-wall-prob` オプションで値を指定します。デフォルトは
@@ -48,7 +48,7 @@ py tag_game.py
 壁を回避した最短経路が緑色の線で表示されます。ステージはポリゴン障害物として
 描画され、
 ステージサイズはデフォルトで
-31x21 ですが、`--width-range` と `--height-range` を指定するとその範囲から
+255x255 ですが、`--width-range` と `--height-range` を指定するとその範囲から
 ランダムに奇数が選ばれます。
 
 また、強化学習向けには `gym_tag_env.py` に `MultiTagEnv` クラスを実装しています。`reset()` でステージとエージェントを再初期化し、`step()` では鬼と逃げのアクションをタプルで与え、観測と報酬も `(鬼, 逃げ)` のタプルで返されます。初期位置は毎回ランダムに選ばれ、必要に応じて `start_distance_range` で互いの距離を制約できます。逃げ側の報酬は捕まったら `-1`、時間いっぱい逃げ切ったら `+1` です。現在の実装では、直線距離ではなく最短経路長の変化を用いて追加報酬を与えます。
@@ -57,7 +57,7 @@ py tag_game.py
 その経路を構成する方向ベクトル列を取得するには `shortest_path_vectors` を利用します。
 
 ```python
-stage = StageMap(31, 21)
+stage = StageMap(255, 255)
 start = pygame.Vector2(1, 1)
 goal = pygame.Vector2(10, 10)
 vectors = stage.shortest_path_vectors(start, goal)

--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -9,7 +9,7 @@ import numpy as np
 import pygame
 
 from stage_generator import generate_stage
-from tag_game import StageMap, Agent, CELL_SIZE
+from tag_game import StageMap, Agent, CELL_SIZE, DRAW_SCALE
 
 INFO_PANEL_HEIGHT = 40
 
@@ -25,8 +25,8 @@ class MultiTagEnv(gym.Env):
 
     def __init__(
         self,
-        width: int = 31,
-        height: int = 21,
+        width: int = 255,
+        height: int = 255,
         max_steps: int = 500,
         extra_wall_prob: float = 0.0,
         speed_multiplier: float = 1.0,
@@ -94,7 +94,10 @@ class MultiTagEnv(gym.Env):
         self.height = self.stage.height
         if self.screen is not None:
             self.screen = pygame.display.set_mode(
-                (self.width * CELL_SIZE, self.height * CELL_SIZE + INFO_PANEL_HEIGHT)
+                (
+                    int(self.width * CELL_SIZE * DRAW_SCALE),
+                    int(self.height * CELL_SIZE * DRAW_SCALE) + INFO_PANEL_HEIGHT,
+                )
             )
         oni_pos = self.stage.random_open_position()
         nige_pos = self.stage.random_open_position()
@@ -206,7 +209,10 @@ class MultiTagEnv(gym.Env):
         if self.screen is None:
             pygame.init()
             self.screen = pygame.display.set_mode(
-                (self.width * CELL_SIZE, self.height * CELL_SIZE + INFO_PANEL_HEIGHT)
+                (
+                    int(self.width * CELL_SIZE * DRAW_SCALE),
+                    int(self.height * CELL_SIZE * DRAW_SCALE) + INFO_PANEL_HEIGHT,
+                )
             )
             self.clock = pygame.time.Clock()
         assert self.stage and self.oni and self.nige
@@ -219,7 +225,12 @@ class MultiTagEnv(gym.Env):
         pygame.draw.rect(
             self.screen,
             (255, 255, 255),
-            pygame.Rect(0, 0, self.width * CELL_SIZE, INFO_PANEL_HEIGHT),
+            pygame.Rect(
+                0,
+                0,
+                int(self.width * CELL_SIZE * DRAW_SCALE),
+                INFO_PANEL_HEIGHT,
+            ),
         )
         offset = (0, INFO_PANEL_HEIGHT)
         self.stage.draw(self.screen, offset)

--- a/stage_generator.py
+++ b/stage_generator.py
@@ -137,8 +137,8 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Generate and print a random stage")
-    parser.add_argument("--width", type=int, default=31, help="Stage width (odd number)")
-    parser.add_argument("--height", type=int, default=21, help="Stage height (odd number)")
+    parser.add_argument("--width", type=int, default=255, help="Stage width (odd number)")
+    parser.add_argument("--height", type=int, default=255, help="Stage height (odd number)")
     parser.add_argument(
         "--extra-wall-prob",
         type=float,


### PR DESCRIPTION
## Summary
- change default map size to `255x255`
- scale drawing so the window size stays similar
- switch shortest path search to A*
- update CLI defaults and documentation

## Testing
- `pytest -q`
- `python -m py_compile tag_game.py gym_tag_env.py stage_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_6865d714a81c8327b721aa55fb1cece7