### PR TITLE
Update default map size

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 ## ステージ生成
 
 ```bash
-python3 stage_generator.py --width 31 --height 21
+python3 stage_generator.py --width 73 --height 51
 ```
 
-実行すると固定サイズ（例: 31x21）のステージが標準出力に表示されます。
+実行すると固定サイズ（例: 73x51）のステージが標準出力に表示されます。
 `generate_stage` 関数に幅・高さを指定することで別サイズのステージも生成可能です。
 ステージには行き止まりが存在せず、孤立したエリアも生じないよう接続性を保ったまま生成されます。道幅はランダムで広げられます。
 壁密度を高めたい場合は `--extra-wall-prob` オプションで値を指定します。デフォルトは
@@ -25,7 +25,7 @@ py tag_game.py
 ```
 実行すると、鬼から逃げまでの経路が `shortest_path_vectors` を用いて計算され、
 壁を回避した最短経路が緑色の線で表示されます。ステージサイズはデフォルトで
-31x21 ですが、`--width-range` と `--height-range` を指定するとその範囲から
+73x51 ですが、`--width-range` と `--height-range` を指定するとその範囲から
 ランダムに奇数が選ばれます。
 
 また、強化学習向けには `gym_tag_env.py` に `MultiTagEnv` クラスを実装しています。`reset()` でステージとエージェントを再初期化し、`step()` では鬼と逃げのアクションをタプルで与え、観測と報酬も `(鬼, 逃げ)` のタプルで返されます。初期位置は毎回ランダムに選ばれ、必要に応じて `start_distance_range` で互いの距離を制約できます。逃げ側の報酬は捕まったら `-1`、時間いっぱい逃げ切ったら `+1` です。現在の実装では、直線距離ではなく最短経路長の変化を用いて追加報酬を与えます。
@@ -34,7 +34,7 @@ py tag_game.py
 その経路を構成する方向ベクトル列を取得するには `shortest_path_vectors` を利用します。
 
 ```python
-stage = StageMap(31, 21)
+stage = StageMap(73, 51)
 start = pygame.Vector2(1, 1)
 goal = pygame.Vector2(10, 10)
 vectors = stage.shortest_path_vectors(start, goal)

--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -25,8 +25,8 @@ class MultiTagEnv(gym.Env):
 
     def __init__(
         self,
-        width: int = 31,
-        height: int = 21,
+        width: int = 73,
+        height: int = 51,
         max_steps: int = 500,
         extra_wall_prob: float = 0.0,
         speed_multiplier: float = 1.0,

--- a/stage_generator.py
+++ b/stage_generator.py
@@ -137,8 +137,8 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Generate and print a random stage")
-    parser.add_argument("--width", type=int, default=31, help="Stage width (odd number)")
-    parser.add_argument("--height", type=int, default=21, help="Stage height (odd number)")
+    parser.add_argument("--width", type=int, default=73, help="Stage width (odd number)")
+    parser.add_argument("--height", type=int, default=51, help="Stage height (odd number)")
     parser.add_argument(
         "--extra-wall-prob",
         type=float,

--- a/tag_game.py
+++ b/tag_game.py
@@ -479,7 +479,7 @@ def main():
         raise SystemExit("--oni または --nige のどちらか一方を指定してください")
 
     pygame.init()
-    width, height = 31, 21
+    width, height = 73, 51
     width_range = None
     height_range = None
     if args.width_range:


### PR DESCRIPTION
## Summary
- increase default stage size from 31x21 to 73x51
- adjust examples in README

## Testing
- `python -m py_compile gym_tag_env.py tag_game.py stage_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_68663887c41c8327abb42ec3daa3ab07