### PR TITLE
Add GPU option to tag_game

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ py train_sac.py --episodes 1000 --render
 | `--games <int>` | 連続対戦数 | 1 |
 | `--oni <path>` | 鬼側モデルのパス（指定すると逃げはプレイヤー操作） | - |
 | `--nige <path>` | 逃げ側モデルのパス（指定すると鬼はプレイヤー操作） | - |
+| `--g` | GPU を利用する(利用可能な場合) | - |
 
 ### `train_sac.py`
 


### PR DESCRIPTION
## Summary
- allow GPU selection for `tag_game.py` via `--g` flag
- display device information like other scripts
- document the new option in README

## Testing
- `python -m py_compile tag_game.py`
- `black --check tag_game.py`

------
https://chatgpt.com/codex/tasks/task_e_68663d2334148327bb84e62d4b2e280c