### PR TITLE
Fix sliding at wall corners

### DIFF
--- a/tag_game.py
+++ b/tag_game.py
@@ -356,29 +356,24 @@ class Agent:
             self.speed_boost = 0.0
         radius = self.radius / CELL_SIZE
 
+        # X 軸方向の移動を先に判定し、壁に衝突する場合はその軸のみ停止する
         new_x = self.pos.x + self.vel.x
-        new_y = self.pos.y + self.vel.y
-
-        if stage.collides_circle(new_x, new_y, radius):
+        if stage.collides_circle(new_x, self.pos.y, radius):
             collided = True
-            # 角にぶつかった場合のスライド処理
-            if not stage.collides_circle(new_x, self.pos.y, radius):
-                # X 方向のみ移動可能
-                self.pos.x = new_x
-                self.vel.y = 0
-                self.speed_boost = 0.0
-            elif not stage.collides_circle(self.pos.x, new_y, radius):
-                # Y 方向のみ移動可能
-                self.pos.y = new_y
-                self.vel.x = 0
-                self.speed_boost = 0.0
-            else:
-                # 両方向とも衝突
-                self.vel.x = 0
-                self.vel.y = 0
-                self.speed_boost = 0.0
+            self.vel.x = 0
+            self.speed_boost = 0.0
         else:
-            self.pos.update(new_x, new_y)
+            self.pos.x = new_x
+
+        # Y 軸方向も同様に処理
+        new_y = self.pos.y + self.vel.y
+        if stage.collides_circle(self.pos.x, new_y, radius):
+            collided = True
+            self.vel.y = 0
+            self.speed_boost = 0.0
+        else:
+            self.pos.y = new_y
+
         return collided
     def draw(self, screen: pygame.Surface, offset: Tuple[int, int] = (0, 0)) -> None:
         off_x, off_y = offset


### PR DESCRIPTION
## Summary
- resolve getting stuck when moving diagonally into corners by sequential axis collision checks

## Testing
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68663db9ef2c8327a9f76ac7b753f1fa