### PR TITLE
Exponential wall collision penalty

### DIFF
--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -188,9 +188,12 @@ class MultiTagEnv(gym.Env):
                 nige_reward = 0.0
             nige_reward += 0.01 * (-dist_delta) + 0.002 * updates
 
-        # small penalty for wall collisions
-        oni_reward -= 0.001 * oni_collisions
-        nige_reward -= 0.001 * nige_collisions
+        # penalty for wall collisions grows exponentially with the number of
+        # hits in this step
+        oni_penalty = 0.001 * (1.5 ** oni_collisions - 1.0)
+        nige_penalty = 0.001 * (1.5 ** nige_collisions - 1.0)
+        oni_reward -= oni_penalty
+        nige_reward -= nige_penalty
 
         # reward is computed for ``updates`` physical steps so that the
         # total reward does not shrink when ``speed_multiplier`` is large


### PR DESCRIPTION
## Summary
- introduce an exponential penalty when agents hit walls

## Testing
- `python3 -m py_compile gym_tag_env.py tag_game.py stage_generator.py evaluate_sac.py train_sac.py`
- `python3 - <<'PY'
import numpy as np
from gym_tag_env import MultiTagEnv
env=MultiTagEnv(width=15, height=15)
obs,_=env.reset()
print('reset ok')
step = env.step((np.array([0.0,0.0],dtype=np.float32), np.array([0.0,0.0],dtype=np.float32)))
print('step result lengths', len(step))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6867337090588327b86e5b36a67be219