### PR TITLE
Unify option names

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ py train_sac.py --episodes 1000 --render
 
 | オプション | 説明 | デフォルト |
 |------------|------|-----------|
-| `--oni-model <path>` | 鬼モデルの保存/読み込みパス | `oni_sac.pth` |
-| `--nige-model <path>` | 逃げモデルの保存/読み込みパス | `nige_sac.pth` |
+| `--oni <path>` | 鬼モデルの保存/読み込みパス | `oni_sac.pth` |
+| `--nige <path>` | 逃げモデルの保存/読み込みパス | `nige_sac.pth` |
 | `--checkpoint-freq <int>` | 指定間隔でチェックポイント保存 | 0 |
 | `--render` | 学習中に画面を描画 | - |
 | `--render-interval <int>` | 描画間隔(ステップ数) | 1 |
@@ -105,8 +105,8 @@ py train_sac.py --episodes 1000 --render
 
 | オプション | 説明 | デフォルト |
 |------------|------|-----------|
-| `--oni-model <path>` | 評価用鬼モデルのパス | `oni_sac.pth` |
-| `--nige-model <path>` | 評価用逃げモデルのパス | `nige_sac.pth` |
+| `--oni <path>` | 評価用鬼モデルのパス | `oni_sac.pth` |
+| `--nige <path>` | 評価用逃げモデルのパス | `nige_sac.pth` |
 | `--episodes <int>` | 評価エピソード数 | 10 |
 | `--render` | 描画を有効化 | - |
 | `--speed-multiplier <float>` | 環境の処理速度倍率 | 1.0 |

--- a/evaluate_sac.py
+++ b/evaluate_sac.py
@@ -14,8 +14,8 @@ from gym_tag_env import MultiTagEnv
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Evaluate SAC trained agents")
-    parser.add_argument("--oni-model", type=str, default="oni_sac.pth", help="Oni model path")
-    parser.add_argument("--nige-model", type=str, default="nige_sac.pth", help="Nige model path")
+    parser.add_argument("--oni", type=str, default="oni_sac.pth", help="Oni model path")
+    parser.add_argument("--nige", type=str, default="nige_sac.pth", help="Nige model path")
     parser.add_argument("--episodes", type=int, default=10, help="Number of episodes")
     parser.add_argument("--render", action="store_true", help="Render environment")
     parser.add_argument("--speed-multiplier", type=float, default=1.0, help="Environment speed multiplier")
@@ -62,10 +62,10 @@ def run_episode(
 
 def main():
     args = parse_args()
-    if not os.path.exists(args.oni_model):
-        raise FileNotFoundError(f"Model not found: {args.oni_model}")
-    if not os.path.exists(args.nige_model):
-        raise FileNotFoundError(f"Model not found: {args.nige_model}")
+    if not os.path.exists(args.oni):
+        raise FileNotFoundError(f"Model not found: {args.oni}")
+    if not os.path.exists(args.nige):
+        raise FileNotFoundError(f"Model not found: {args.nige}")
     device = torch.device("cuda" if args.g and torch.cuda.is_available() else "cpu")
     if args.g and device.type != "cuda":
         print("GPU is not available. Falling back to CPU.")
@@ -79,12 +79,12 @@ def main():
     action_dim = env.action_space.shape[0]
 
     oni_actor = Actor(obs_dim, action_dim).to(device)
-    oni_state = torch.load(args.oni_model, map_location=device)
+    oni_state = torch.load(args.oni, map_location=device)
     oni_actor.load_state_dict(oni_state["actor"])
     oni_actor.eval()
 
     nige_actor = Actor(obs_dim, action_dim).to(device)
-    nige_state = torch.load(args.nige_model, map_location=device)
+    nige_state = torch.load(args.nige, map_location=device)
     nige_actor.load_state_dict(nige_state["actor"])
     nige_actor.eval()
 

--- a/train_sac.py
+++ b/train_sac.py
@@ -20,8 +20,8 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Soft Actor-Critic training for MultiTagEnv"
     )
-    parser.add_argument("--oni-model", type=str, default="oni_sac.pth", help="Path to save oni model")
-    parser.add_argument("--nige-model", type=str, default="nige_sac.pth", help="Path to save nige model")
+    parser.add_argument("--oni", type=str, default="oni_sac.pth", help="Path to save oni model")
+    parser.add_argument("--nige", type=str, default="nige_sac.pth", help="Path to save nige model")
     parser.add_argument("--checkpoint-freq", type=int, default=0, help="Save checkpoints every N steps")
     parser.add_argument("--render", action="store_true", help="Render environment during training")
     parser.add_argument("--render-interval", type=int, default=1, help="Render every N steps")
@@ -238,8 +238,8 @@ def run_training(args: argparse.Namespace) -> None:
     episode_rewards_nige: list[float] = []
 
     output_dir = _timestamp_output_dir("out")
-    oni_model_path = os.path.join(output_dir, args.oni_model)
-    nige_model_path = os.path.join(output_dir, args.nige_model)
+    oni_model_path = os.path.join(output_dir, args.oni)
+    nige_model_path = os.path.join(output_dir, args.nige)
 
     total_steps = 0
     for ep in range(1, args.episodes + 1):


### PR DESCRIPTION
## Summary
- shorten argument names across scripts
- update documentation

## Testing
- `python -m py_compile train_sac.py evaluate_sac.py tag_game.py gym_tag_env.py stage_generator.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68673fb7bef08327805013db5428c039