### PR TITLE
Adjust oni speed

### DIFF
--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -10,7 +10,16 @@ import pygame
 import torch
 
 from stage_generator import generate_stage
-from tag_game import StageMap, Agent, CELL_SIZE, MAX_SPEED_BOOST
+from tag_game import (
+    StageMap,
+    Agent,
+    CELL_SIZE,
+    MAX_SPEED_BOOST,
+    NIGE_MAX_SPEED,
+    NIGE_ACCEL_STEPS,
+    ONI_MAX_SPEED,
+    ONI_ACCEL_STEPS,
+)
 
 INFO_PANEL_HEIGHT = 40
 
@@ -290,8 +299,20 @@ class MultiTagEnv(gym.Env):
                 nige_pos = self.stage.random_open_position()
                 _, d = self.stage.shortest_path_info(oni_pos, nige_pos)
                 tries += 1
-        self.oni = Agent(oni_pos.x, oni_pos.y, (255, 0, 0))
-        self.nige = Agent(nige_pos.x, nige_pos.y, (0, 100, 255))
+        self.nige = Agent(
+            nige_pos.x,
+            nige_pos.y,
+            (0, 100, 255),
+            max_speed=NIGE_MAX_SPEED,
+            accel_steps=NIGE_ACCEL_STEPS,
+        )
+        self.oni = Agent(
+            oni_pos.x,
+            oni_pos.y,
+            (255, 0, 0),
+            max_speed=ONI_MAX_SPEED,
+            accel_steps=ONI_ACCEL_STEPS,
+        )
         self.oni_history = [(self.oni.pos.x, self.oni.pos.y)]
         self.nige_history = [(self.nige.pos.x, self.nige.pos.y)]
         self.step_count = 0

--- a/tag_game.py
+++ b/tag_game.py
@@ -57,6 +57,17 @@ DEFAULT_DURATION = 10.0
 CONTINUOUS_ACCEL = 0.01
 MAX_SPEED_BOOST = 0.3
 
+# --- 速度設定 ---
+# デフォルトの逃げ側パラメータ
+NIGE_MAX_SPEED = 0.2
+NIGE_ACCEL_STEPS = 4
+NIGE_ACCEL = NIGE_MAX_SPEED / NIGE_ACCEL_STEPS
+
+# 鬼側は逃げよりも高速・高加速度
+ONI_MAX_SPEED = NIGE_MAX_SPEED * 1.2
+ONI_ACCEL = NIGE_ACCEL * 2
+ONI_ACCEL_STEPS = ONI_MAX_SPEED / ONI_ACCEL
+
 
 class StageMap:
     def __init__(
@@ -543,8 +554,20 @@ def main():
         start = time.time()
         end_time = start + args.duration
 
-        oni = Agent(1.5, 1.5, (255, 0, 0))
-        nige = Agent(width - 2, height - 2, (0, 100, 255))
+        nige = Agent(
+            width - 2,
+            height - 2,
+            (0, 100, 255),
+            max_speed=NIGE_MAX_SPEED,
+            accel_steps=NIGE_ACCEL_STEPS,
+        )
+        oni = Agent(
+            1.5,
+            1.5,
+            (255, 0, 0),
+            max_speed=ONI_MAX_SPEED,
+            accel_steps=ONI_ACCEL_STEPS,
+        )
 
         running = True
         result = "timeout"


### PR DESCRIPTION
## Summary
- customize speed constants so oni is 1.2x faster than nige
- double oni acceleration relative to nige
- apply these parameters in the game loop and Gym environment

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6867f0a13ef48327976ba505dc31314c