### PR TITLE
Adjust default map params

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 ## ステージ生成
 
 ```bash
-python3 stage_generator.py --w 73 --h 51
+python3 stage_generator.py --w 31 --h 21
 ```
 
-実行すると固定サイズ（例: 73x51）のステージが標準出力に表示されます。
+実行すると固定サイズ（例: 31x21）のステージが標準出力に表示されます。
 `generate_stage` 関数に幅・高さを指定することで別サイズのステージも生成可能です。
 ステージには行き止まりが存在せず、孤立したエリアも生じないよう接続性を保ったまま生成されます。道幅はランダムで広げられます。
 壁密度を高めたい場合は `--extra-wall` オプションで値を指定します。デフォルトは
-`0.1` です。
+`0.15` です。
 
 ## 鬼ごっこ環境
 
@@ -25,7 +25,7 @@ py tag_game.py
 ```
 実行すると、鬼から逃げまでの経路が `shortest_path_vectors` を用いて計算され、
 壁を回避した最短経路が緑色の線で表示されます。ステージサイズはデフォルトで
-73x51 ですが、`--w-range` と `--h-range` を指定するとその範囲から
+31x21 ですが、`--w-range` と `--h-range` を指定するとその範囲から
 ランダムに奇数が選ばれます。
 
 また、強化学習向けには `gym_tag_env.py` に `MultiTagEnv` クラスを実装しています。`reset()` でステージとエージェントを再初期化し、`step()` では鬼と逃げのアクションをタプルで与え、観測と報酬も `(鬼, 逃げ)` のタプルで返されます。初期位置は毎回ランダムに選ばれ、必要に応じて `start_distance_range` で互いの距離を制約できます。逃げ側の報酬は捕まったら `-1`、時間いっぱい逃げ切ったら `+1` です。現在の実装では、直線距離ではなく最短経路長の変化を用いて追加報酬を与えます。CNN 入力用の多チャンネル観測テンソルは `reset()` と `step()` が返す `info` 辞書（`"oni_tensor"`, `"nige_tensor"`）に含まれます。
@@ -35,7 +35,7 @@ py tag_game.py
 その経路を構成する方向ベクトル列を取得するには `shortest_path_vectors` を利用します。
 
 ```python
-stage = StageMap(73, 51)
+stage = StageMap(31, 21)
 start = pygame.Vector2(1, 1)
 goal = pygame.Vector2(10, 10)
 vectors = stage.shortest_path_vectors(start, goal)

--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -38,10 +38,10 @@ class MultiTagEnv(gym.Env):
 
     def __init__(
         self,
-        width: int = 73,
-        height: int = 51,
+        width: int = 31,
+        height: int = 21,
         max_steps: int = 500,
-        extra_wall_prob: float = 0.0,
+        extra_wall_prob: float = 0.1,
         speed_multiplier: float = 1.0,
         render_speed: float = 1.0,
         start_distance_range: tuple[int, int] | None = None,

--- a/stage_generator.py
+++ b/stage_generator.py
@@ -137,14 +137,14 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Generate and print a random stage")
-    parser.add_argument("--w", "--width", dest="width", type=int, default=73, help="Stage width (odd number)")
-    parser.add_argument("--h", "--height", dest="height", type=int, default=51, help="Stage height (odd number)")
+    parser.add_argument("--w", "--width", dest="width", type=int, default=31, help="Stage width (odd number)")
+    parser.add_argument("--h", "--height", dest="height", type=int, default=21, help="Stage height (odd number)")
     parser.add_argument(
         "--extra-wall",
         "--extra-wall-prob",
         dest="extra_wall_prob",
         type=float,
-        default=0.1,
+        default=0.15,
         help="Probability of adding extra walls after maze generation",
     )
     args = parser.parse_args()

--- a/tag_game.py
+++ b/tag_game.py
@@ -101,7 +101,7 @@ class CNNActor(torch.nn.Module):
 
 
 CELL_SIZE = 20
-EXTRA_WALL_PROB = 0.1
+EXTRA_WALL_PROB = 0.15
 INFO_PANEL_HEIGHT = 40
 DEFAULT_DURATION = 10.0
 
@@ -689,7 +689,7 @@ def main():
     spectator_mode = args.oni is not None and args.nige is not None
 
     pygame.init()
-    width, height = 73, 51
+    width, height = 31, 21
     width_range = None
     height_range = None
     if args.width_range:


### PR DESCRIPTION
## Summary
- reduce default map size to 31x21
- increase wall density by default

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 stage_generator.py --w 31 --h 21 --extra-wall 0.15 | head -n 5`
- `python3 - <<'EOF'
from gym_tag_env import MultiTagEnv
env = MultiTagEnv()
obs, info = env.reset()
print(env.width, env.height)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686802cccac08327bf4dcb0b15acb211