### PR TITLE
Improve movement and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ py train_sac.py --eps 1000 --draw
 `out/YYYYMMDD_HHMMSS/nige_sac.pth` に保存されます。
 
 同じディレクトリにはエピソードごとの報酬を記録した `rewards.csv` と、
-それを基に描画した学習曲線 `learning_curve.png` も生成されます。
+それを基に描画した学習曲線 `learning_curve.png`、
+ステップごとの詳細ログ `step_log.csv` も生成されます。
 これらを参照することで学習の進捗を確認できます。
 
 
@@ -88,8 +89,8 @@ py train_sac.py --eps 1000 --draw
 
 | オプション | 説明 | デフォルト |
 |------------|------|-----------|
-| `--oni <path>` | 鬼モデルの保存/読み込みパス | `oni_sac.pth` |
-| `--nige <path>` | 逃げモデルの保存/読み込みパス | `nige_sac.pth` |
+| `--oni, -O <path>` | 鬼モデルの保存/読み込みパス | `oni_sac.pth` |
+| `--nige, -N <path>` | 逃げモデルの保存/読み込みパス | `nige_sac.pth` |
 | `--load-oni <path>` | 既存の鬼モデルを読み込んで再学習 | - |
 | `--load-nige <path>` | 既存の逃げモデルを読み込んで再学習 | - |
 | `--ckpt <int>` | 指定間隔でチェックポイント保存 | 0 |
@@ -115,8 +116,8 @@ py train_sac.py --eps 1000 --draw
 
 | オプション | 説明 | デフォルト |
 |------------|------|-----------|
-| `--oni <path>` | 評価用鬼モデルのパス | `oni_sac.pth` |
-| `--nige <path>` | 評価用逃げモデルのパス | `nige_sac.pth` |
+| `--oni, -O <path>` | 評価用鬼モデルのパス | `oni_sac.pth` |
+| `--nige, -N <path>` | 評価用逃げモデルのパス | `nige_sac.pth` |
 | `--eps <int>` | 評価エピソード数 | 10 |
 | `--draw` | 描画を有効化 | - |
 | `--speed <float>` | 環境の処理速度倍率 | 1.0 |

--- a/evaluate_sac.py
+++ b/evaluate_sac.py
@@ -14,8 +14,20 @@ from gym_tag_env import MultiTagEnv
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Evaluate SAC trained agents")
-    parser.add_argument("--oni", type=str, default="oni_sac.pth", help="Oni model path")
-    parser.add_argument("--nige", type=str, default="nige_sac.pth", help="Nige model path")
+    parser.add_argument(
+        "--oni",
+        "-O",
+        type=str,
+        default="oni_sac.pth",
+        help="Oni model path",
+    )
+    parser.add_argument(
+        "--nige",
+        "-N",
+        type=str,
+        default="nige_sac.pth",
+        help="Nige model path",
+    )
     parser.add_argument("--eps", "--episodes", dest="episodes", type=int, default=10, help="Number of episodes")
     parser.add_argument("--draw", "--render", dest="render", action="store_true", help="Render environment")
     parser.add_argument("--speed", "--speed-multiplier", dest="speed_multiplier", type=float, default=1.0, help="Environment speed multiplier")
@@ -55,12 +67,13 @@ def run_episode(
     done = False
     total_rewards = [0.0, 0.0]
     while not done:
-        if use_cnn:
-            oni_action = oni_actor.act(oni_obs, oni_tensor)
-            nige_action = nige_actor.act(nige_obs, nige_tensor)
-        else:
-            oni_action = oni_actor.act(oni_obs)
-            nige_action = nige_actor.act(nige_obs)
+        with torch.no_grad():
+            if use_cnn:
+                oni_action = oni_actor.act(oni_obs, oni_tensor)
+                nige_action = nige_actor.act(nige_obs, nige_tensor)
+            else:
+                oni_action = oni_actor.act(oni_obs)
+                nige_action = nige_actor.act(nige_obs)
         (oni_obs, nige_obs), (r_on, r_ni), terminated, truncated, info = env.step((oni_action, nige_action))
         oni_tensor = info["oni_tensor"]
         nige_tensor = info["nige_tensor"]

--- a/gym_tag_env.py
+++ b/gym_tag_env.py
@@ -443,6 +443,10 @@ class MultiTagEnv(gym.Env):
         # reward is computed for ``updates`` physical steps so that the
         # total reward does not shrink when ``speed_multiplier`` is large
 
+        # 報酬を [-1, 1] の範囲に収める
+        oni_reward = float(max(-1.0, min(oni_reward, 1.0)))
+        nige_reward = float(max(-1.0, min(nige_reward, 1.0)))
+
         self.last_rewards = (oni_reward, nige_reward)
         self.cumulative_rewards[0] += oni_reward
         self.cumulative_rewards[1] += nige_reward
@@ -450,8 +454,15 @@ class MultiTagEnv(gym.Env):
         info = {
             "oni_tensor": oni_tensor,
             "nige_tensor": nige_tensor,
+            "distance": new_dist,
         }
-        return (oni_obs, nige_obs), (oni_reward, nige_reward), terminated, truncated, info
+        return (
+            (oni_obs, nige_obs),
+            (oni_reward, nige_reward),
+            terminated,
+            truncated,
+            info,
+        )
 
     def render(self) -> None:
         if self.screen is None:


### PR DESCRIPTION
## Summary
- make wall collision allow sliding along walls
- clip rewards to [-1, 1] and return distance info
- log per-step rewards to `step_log.csv`
- add short CLI options `-O`/`-N`
- document new logs and options

## Testing
- `python -m py_compile tag_game.py gym_tag_env.py train_sac.py evaluate_sac.py`

------
https://chatgpt.com/codex/tasks/task_e_686ba1439b748327a9ba2dc55add60bd