### PR TITLE
Enhance tag env dynamics

### DIFF
--- a/evaluate_sac.py
+++ b/evaluate_sac.py
@@ -99,6 +99,7 @@ def main():
     env = MultiTagEnv(
         speed_multiplier=args.speed_multiplier,
         render_speed=args.render_speed,
+        start_distance_range=(15, None),
     )
     obs_dim = env.observation_space.shape[0]
     action_dim = env.action_space.shape[0]

--- a/tag_game.py
+++ b/tag_game.py
@@ -526,6 +526,11 @@ def make_obs(
     ovx = np.clip(opponent.vel.x / ov_scale, -1.0, 1.0)
     ovy = np.clip(opponent.vel.y / ov_scale, -1.0, 1.0)
 
+    pred_x = min(max(opponent.pos.x + opponent.vel.x * 2, 0), stage.width - 1)
+    pred_y = min(max(opponent.pos.y + opponent.vel.y * 2, 0), stage.height - 1)
+    pred_x = pred_x / stage.width * 2.0 - 1.0
+    pred_y = pred_y / stage.height * 2.0 - 1.0
+
     remain_ratio = max(0.0, 1.0 - step_count / float(max_steps))
 
     return np.array(
@@ -541,6 +546,8 @@ def make_obs(
             ovx,
             ovy,
             remain_ratio,
+            pred_x,
+            pred_y,
         ],
         dtype=np.float32,
     )


### PR DESCRIPTION
## Summary
- encourage movement via idle penalties and start distance constraint
- embed opponent prediction in vector observations
- allow training interval control
- randomize spawn distance for evaluation

## Testing
- `python -m py_compile gym_tag_env.py train_sac.py evaluate_sac.py tag_game.py`
- `pip install -r requirements.txt`
- `python train_sac.py --eps 1 --time 1 --train-every 2 --buf 10 --batch 2 --eval-int 1 --eval-eps 1`

------
https://chatgpt.com/codex/tasks/task_e_686bb58d31a88327a94fcd85feadb0c3