### PR TITLE
Fix dimension mismatch in Actor act

### DIFF
--- a/tag_game.py
+++ b/tag_game.py
@@ -42,7 +42,13 @@ class Actor(torch.nn.Module):
 
     def act(self, obs: np.ndarray) -> np.ndarray:
         device = next(self.parameters()).device
-        obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
+        obs_t = torch.as_tensor(obs, dtype=torch.float32, device=device)
+        in_dim = self.net[0].in_features
+        if obs_t.shape[-1] > in_dim:
+            obs_t = obs_t[..., :in_dim]
+        elif obs_t.shape[-1] < in_dim:
+            pad = torch.zeros(in_dim - obs_t.shape[-1], device=device)
+            obs_t = torch.cat([obs_t, pad], dim=-1)
         with torch.no_grad():
             action, _ = self.sample(obs_t.unsqueeze(0))
         return action.squeeze(0).cpu().numpy()

--- a/train_sac.py
+++ b/train_sac.py
@@ -116,7 +116,13 @@ class Actor(nn.Module):
 
     def act(self, obs: np.ndarray) -> np.ndarray:
         device = next(self.parameters()).device
-        obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
+        obs_t = torch.as_tensor(obs, dtype=torch.float32, device=device)
+        in_dim = self.net[0].in_features
+        if obs_t.shape[-1] > in_dim:
+            obs_t = obs_t[..., :in_dim]
+        elif obs_t.shape[-1] < in_dim:
+            pad = torch.zeros(in_dim - obs_t.shape[-1], device=device)
+            obs_t = torch.cat([obs_t, pad], dim=-1)
         with torch.no_grad():
             action, _ = self.sample(obs_t.unsqueeze(0))
         return action.squeeze(0).cpu().numpy()


### PR DESCRIPTION
## Summary
- avoid mismatched observation size when using saved models
- fill or slice observations in `act` to match network input

## Testing
- `python -m py_compile train_sac.py tag_game.py`

------
https://chatgpt.com/codex/tasks/task_e_686bc894fa508327bffeb51d432c7b90