### PR TITLE
Fix actor loading dimension

### DIFF
--- a/tag_game.py
+++ b/tag_game.py
@@ -749,7 +749,11 @@ def main():
         sd = state["actor"] if "actor" in state else state
         is_cnn = any(k.startswith("encoder.") for k in sd.keys())
         cls = CNNActor if is_cnn else Actor
-        obs_dim = 11 if is_cnn else 3
+        if is_cnn:
+            feature_dim = sd["encoder.fc.weight"].shape[0]
+            obs_dim = sd["net.0.weight"].shape[1] - feature_dim
+        else:
+            obs_dim = sd["net.0.weight"].shape[1]
         actor = cls(obs_dim, 2).to(device)
         actor.load_state_dict(sd)
         actor.eval()


### PR DESCRIPTION
## Summary
- detect observation dimension from model weights when loading actors in tag_game

## Testing
- `python -m py_compile tag_game.py`
- `python -m py_compile train_sac.py evaluate_sac.py gym_tag_env.py cnn_models.py config_util.py stage_generator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bccc8d5008327a13fc4c3bb946f8d